### PR TITLE
Add requirements-dev for non prod dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Clone the repository
 
 From the top-level directory enter the command to install pip and the dependencies of the project
 
-    python3 -m pip install --upgrade pip && pip install -r requirements.txt
+    python3 -m pip install --upgrade pip && pip install -r requirements-dev.txt
 
 ## How to use
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+pytest
+flake8
+black


### PR DESCRIPTION
Previously we expected an (undocumented) global installation of tools such as `pytest`. This adds a dev requirements file so they are included in the virtual env.