### PR TITLE
Revert "BAU : Added logit to manifest"

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -14,7 +14,6 @@ applications:
   health-check-type: http
   services:
     - application-store-dev-db
-    - logit-ssl-drain
 
 - name: funding-service-design-application-store-test
   memory: 256M
@@ -30,4 +29,3 @@ applications:
   health-check-type: http
   services:
     - application-store-test-db
-    - logit-ssl-drain


### PR DESCRIPTION
Reverts communitiesuk/funding-service-design-application-store#31

We need to revert this as it won't log currently unless we're using Gunicorn to run the app with our logging templates.