### PR TITLE
BAU - Fixing psycopg2 dependency

### DIFF
--- a/.github/workflows/manual-dev-deploy.yaml
+++ b/.github/workflows/manual-dev-deploy.yaml
@@ -1,9 +1,6 @@
   name: Manual Dev Deploy
   on:
     workflow_dispatch:
-    push:
-      branches:
-        - bau-fix-depends
   jobs:
     deploy_dev:
       runs-on: ubuntu-latest

--- a/.github/workflows/manual-dev-deploy.yaml
+++ b/.github/workflows/manual-dev-deploy.yaml
@@ -22,9 +22,6 @@
         - name: upgrade db (if specified)
           if: ${{inputs.upgrade_db == true}}
           run: source .venv/bin/activate && python -m flask db upgrade
-        - name: build static assets (if frontend)
-          if: ${{inputs.assets_required == true}}
-          run: python build.py
         - name: download previous build
           uses: actions/download-artifact@v2
         - name: Deploy to Gov PaaS
@@ -35,4 +32,4 @@
             cf_space:    ${{secrets.CF_SPACE }}
             cf_username: ${{secrets.CF_USER}}
             cf_password: ${{secrets.CF_PASSWORD}}
-            command: push ${{inputs.app_name}}-dev
+            command: push funding-service-design-application-store-dev

--- a/.github/workflows/manual-dev-deploy.yaml
+++ b/.github/workflows/manual-dev-deploy.yaml
@@ -1,6 +1,8 @@
   deploy_dev:
     on:
-      workflow_dispatch:
+      push:
+        branches:
+          - bau-fix-depends
     runs-on: ubuntu-latest
     environment: Dev
     steps:

--- a/.github/workflows/manual-dev-deploy.yaml
+++ b/.github/workflows/manual-dev-deploy.yaml
@@ -1,4 +1,6 @@
   deploy_dev:
+    on:
+      workflow_dispatch:
     runs-on: ubuntu-latest
     environment: Dev
     steps:

--- a/.github/workflows/manual-dev-deploy.yaml
+++ b/.github/workflows/manual-dev-deploy.yaml
@@ -1,35 +1,38 @@
-  deploy_dev:
-    on:
-      push:
-        branches:
-          - bau-fix-depends
-    runs-on: ubuntu-latest
-    environment: Dev
-    steps:
-      - name: checkout code
-        uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.10.1
-      - name: create python env
-        run: python -m venv .venv
-      - name: install dependencies
-        run: source .venv/bin/activate && python -m pip install --upgrade pip && pip install -r requirements.txt
-      - name: upgrade db (if specified)
-        if: ${{inputs.upgrade_db == true}}
-        run: source .venv/bin/activate && python -m flask db upgrade
-      - name: build static assets (if frontend)
-        if: ${{inputs.assets_required == true}}
-        run: python build.py
-      - name: download previous build
-        uses: actions/download-artifact@v2
-      - name: Deploy to Gov PaaS
-        uses: citizen-of-planet-earth/cf-cli-action@v2
-        with:
-          cf_api:      ${{secrets.CF_API}}
-          cf_org:      ${{secrets.CF_ORG}}
-          cf_space:    ${{secrets.CF_SPACE }}
-          cf_username: ${{secrets.CF_USER}}
-          cf_password: ${{secrets.CF_PASSWORD}}
-          command: push ${{inputs.app_name}}-dev
+  name: Manual Dev Deploy
+  on:
+    workflow_dispatch:
+    push:
+      branches:
+        - bau-fix-depends
+  jobs:
+    deploy_dev:
+      runs-on: ubuntu-latest
+      environment: Dev
+      steps:
+        - name: checkout code
+          uses: actions/checkout@v2
+        - name: Set up Python
+          uses: actions/setup-python@v2
+          with:
+            python-version: 3.10.1
+        - name: create python env
+          run: python -m venv .venv
+        - name: install dependencies
+          run: source .venv/bin/activate && python -m pip install --upgrade pip && pip install -r requirements.txt
+        - name: upgrade db (if specified)
+          if: ${{inputs.upgrade_db == true}}
+          run: source .venv/bin/activate && python -m flask db upgrade
+        - name: build static assets (if frontend)
+          if: ${{inputs.assets_required == true}}
+          run: python build.py
+        - name: download previous build
+          uses: actions/download-artifact@v2
+        - name: Deploy to Gov PaaS
+          uses: citizen-of-planet-earth/cf-cli-action@v2
+          with:
+            cf_api:      ${{secrets.CF_API}}
+            cf_org:      ${{secrets.CF_ORG}}
+            cf_space:    ${{secrets.CF_SPACE }}
+            cf_username: ${{secrets.CF_USER}}
+            cf_password: ${{secrets.CF_PASSWORD}}
+            command: push ${{inputs.app_name}}-dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ FROM python:3.10-bullseye
 RUN apt update && apt -yq install git
 
 WORKDIR /app
-COPY requirements.txt requirements.txt
-RUN python3 -m pip install --upgrade pip && pip install -r requirements.txt
+COPY requirements-dev.txt requirements-dev.txt
+RUN python3 -m pip install --upgrade pip && pip install -r requirements-dev.txt
 COPY . .
 
 EXPOSE 8080

--- a/config/envs/dev.py
+++ b/config/envs/dev.py
@@ -1,5 +1,6 @@
 """Flask configuration."""
 import logging
+from os import environ
 
 from config.envs.default import DefaultConfig
 from fsd_utils import configclass
@@ -10,3 +11,7 @@ class DevConfig(DefaultConfig):
 
     FSD_LOGGING_LEVEL = logging.INFO
     SQLALCHEMY_TRACK_MODIFICATIONS = False
+
+    SQLALCHEMY_DATABASE_URI = environ.get("DATABASE_URL").replace(
+        "postgres://", "postgresql://"
+    )

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -9,3 +9,4 @@ pytest-flask
 pip-tools
 asserts
 pytest-flask-sqlalchemy
+psycopg2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -178,9 +178,9 @@ prance==0.21.8.0
 pre-commit==2.19.0
     # via -r requirements-dev.in
 psycopg2==2.9.3
-    # via -r requirements-dev.in
-psycopg2-binary==2.9.3
-    # via -r requirements.txt
+    # via
+    #   -r requirements-dev.in
+    #   -r requirements.txt
 py==1.11.0
     # via pytest
 pycparser==2.21

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -96,10 +96,6 @@ gitdb==4.0.9
     # via gitpython
 gitpython==3.1.27
     # via bandit
-greenlet==1.1.2
-    # via
-    #   -r requirements.txt
-    #   sqlalchemy
 gunicorn==20.1.0
     # via
     #   -r requirements.txt
@@ -180,6 +176,8 @@ pluggy==1.0.0
 prance==0.21.8.0
     # via -r requirements.txt
 pre-commit==2.19.0
+    # via -r requirements-dev.in
+psycopg2==2.9.3
     # via -r requirements-dev.in
 psycopg2-binary==2.9.3
     # via -r requirements.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -178,9 +178,9 @@ prance==0.21.8.0
 pre-commit==2.19.0
     # via -r requirements-dev.in
 psycopg2==2.9.3
-    # via
-    #   -r requirements-dev.in
-    #   -r requirements.txt
+    # via -r requirements-dev.in
+psycopg2-binary==2.9.3
+    # via -r requirements.txt
 py==1.11.0
     # via pytest
 pycparser==2.21

--- a/requirements.in
+++ b/requirements.in
@@ -18,4 +18,4 @@ Flask-SQLAlchemy
 Flask-Migrate
 sqlalchemy-utils
 sqlalchemy_json
-psycopg2-binary
+psycopg2

--- a/requirements.in
+++ b/requirements.in
@@ -18,4 +18,4 @@ Flask-SQLAlchemy
 Flask-Migrate
 sqlalchemy-utils
 sqlalchemy_json
-psycopg2
+psycopg2-binary

--- a/requirements.txt
+++ b/requirements.txt
@@ -85,7 +85,7 @@ packaging==21.3
     # via connexion
 prance==0.21.8.0
     # via -r requirements.in
-psycopg2-binary==2.9.3
+psycopg2==2.9.3
     # via -r requirements.in
 pycparser==2.21
     # via cffi

--- a/requirements.txt
+++ b/requirements.txt
@@ -85,7 +85,7 @@ packaging==21.3
     # via connexion
 prance==0.21.8.0
     # via -r requirements.in
-psycopg2==2.9.3
+psycopg2-binary==2.9.3
     # via -r requirements.in
 pycparser==2.21
     # via cffi

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,8 +49,6 @@ flask-sqlalchemy==2.5.1
     #   flask-migrate
 funding-service-design-utils @ https://github.com/communitiesuk/funding-service-design-utils/archive/refs/tags/0.0.14.tar.gz
     # via -r requirements.in
-greenlet==1.1.2
-    # via sqlalchemy
 gunicorn==20.1.0
     # via funding-service-design-utils
 idna==3.3


### PR DESCRIPTION
Psycopg2 is now included differently for dev or non-dev requirements:
- `requirements-dev` uses `psycopg2` as we need the source for running docker locally
- `requirements` uses `psycopg2-binary` as it includes everything needed to run on paas.
Also:
- Fixed manual deploy dev workflow
- updated the postgres url in dev config