### PR TITLE
FS-1897 status search endpoint added.

### DIFF
--- a/openapi/api.yml
+++ b/openapi/api.yml
@@ -40,6 +40,13 @@ paths:
           required: false
           explode: false
         - in: query
+          name: status_only
+          style: form
+          schema:
+            type: string
+          required: false
+          explode: false
+        - in: query
           name: fund_id
           style: form
           schema:


### PR DESCRIPTION
- Corrects the api yaml so that the status searching option is an valid option. This is needed for loading into assessment.
- Adds a test which checks that submitted applications actually become submitted and are retrieved by the endpoint. 
- Renames some test helper functions to be clearer.