### PR TITLE
FS-1928: get forms using foreign key instead of separate lookup

### DIFF
--- a/db/models/aggregate_functions.py
+++ b/db/models/aggregate_functions.py
@@ -284,7 +284,7 @@ def get_report_for_all_applications(application_id=None):
             "organisation_type": None,
             "revenue": None,
         }
-        stored_forms = FormsMethods.get_forms_by_app_id(application.id)
+        stored_forms = [form.as_json() for form in application.forms]
         list_of_forms = [
             {
                 "form_name": "organisation-information",

--- a/db/models/applications.py
+++ b/db/models/applications.py
@@ -5,12 +5,13 @@ import uuid
 from api.routes.application.helpers import get_fund
 from api.routes.application.helpers import get_round
 from db import db
-from db.models.status import Status
 from db.models.language import Language
+from db.models.status import Status
 from flask import current_app
 from sqlalchemy import DateTime
 from sqlalchemy.dialects.postgresql import ENUM
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import relationship
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.sql import func
 from sqlalchemy_utils.types import UUIDType
@@ -28,9 +29,7 @@ class Applications(db.Model):
     fund_id = db.Column("fund_id", db.String(), nullable=False)
     round_id = db.Column("round_id", db.String(), nullable=False)
     key = db.Column("key", db.String(), nullable=False)
-    language = db.Column(
-        "language", ENUM(Language), nullable=True
-    )
+    language = db.Column("language", ENUM(Language), nullable=True)
     reference = db.Column(
         "reference", db.String(), nullable=False, unique=True
     )
@@ -45,6 +44,7 @@ class Applications(db.Model):
     )
     date_submitted = db.Column("date_submitted", DateTime())
     last_edited = db.Column("last_edited", DateTime())
+    forms = relationship("Forms")
 
     __table_args__ = (
         db.UniqueConstraint("fund_id", "round_id", "key", name="_reference"),


### PR DESCRIPTION
Previously we made a separate call for forms for each applications, this uses the foreign key to establish a one-to-many relationship so the forms are returned as part of the application model.