### PR TITLE
BAU: fix boolean logic

### DIFF
--- a/db/models/aggregate_functions.py
+++ b/db/models/aggregate_functions.py
@@ -202,7 +202,7 @@ def update_form(
 
 
 def update_project_name(form_name, question_json, application):
-    if form_name == ("project-information" or "gwybodaeth-am-y-prosiect"):
+    if form_name in ("project-information", "gwybodaeth-am-y-prosiect"):
         for question in question_json:
             for field in question["fields"]:
                 # field id for project name in json

--- a/db/models/aggregate_functions.py
+++ b/db/models/aggregate_functions.py
@@ -202,7 +202,7 @@ def update_form(
 
 
 def update_project_name(form_name, question_json, application):
-    if form_name == "project-information" or "gwybodaeth-am-y-prosiect":
+    if form_name == ("project-information" or "gwybodaeth-am-y-prosiect"):
         for question in question_json:
             for field in question["fields"]:
                 # field id for project name in json


### PR DESCRIPTION
Spotted in the course of another story:
Previously this was unintentionally always evaluating to True as `"gwybodaeth-am-y-prosiect"` was always truthy due to missing brackets.
