### PR TITLE
BAU: safe lookup on language

### DIFF
--- a/db/models/applications.py
+++ b/db/models/applications.py
@@ -59,7 +59,7 @@ class Applications(db.Model):
             "account_id": self.account_id,
             "round_id": self.round_id,
             "fund_id": self.fund_id,
-            "language": self.language.name or "en",
+            "language": self.language.name if self.language else "en",
             "reference": self.reference,
             "project_name": self.project_name or None,
             "started_at": self.started_at.isoformat(),


### PR DESCRIPTION
Previously we were making an unsafe lookup on the language enum, so existing applications without a language set were throwing an exception:
```
AttributeError
'NoneType' object has no attribute 'name'
```
this fixes it to the intended behaviour of falling back to `en` if not set.

Note: we probably should test this but the existing test setup makes this difficult so would rather get this hot-fix out as-is.