### PR TITLE
FS-2022: bump python version

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.10.x
+python-3.11.x


### PR DESCRIPTION
changes in https://github.com/communitiesuk/funding-service-design-application-store/pull/97 depend on Python 3.11

So changing the PaaS version to match this.

------

On PaaS we were getting the exception: 
```
ImportError: cannot import name 'Self' from 'typing' (/usr/local/lib/python3.10/typing.py)
``` 
because we were trying to use a Python 3.11 feature on Python 3.10

