### PR TITLE
FS-2022: remove python 3.11 feature

### DIFF
--- a/external_services/models/fund.py
+++ b/external_services/models/fund.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 from typing import List
 from typing import Optional
-from typing import Self
 
 from external_services.models.round import Round
 from flask import current_app
@@ -16,7 +15,7 @@ class Fund:
     rounds: Optional[List[Round]] = None
 
     @staticmethod
-    def from_json(data: dict) -> Self:
+    def from_json(data: dict):
         try:
             return Fund(
                 name=data["name"],


### PR DESCRIPTION
On PaaS we were getting the exception: 
```
ImportError: cannot import name 'Self' from 'typing' (/usr/local/lib/python3.10/typing.py)
``` 
because we were trying to use a Python 3.11 feature on Python 3.10

