### PR TITLE
bug install missing deps.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.10-bullseye
 
 # install git as pip needs to clone fsd_utils
-RUN apt update && apt -yq install git
+RUN apt update && apt -yq install git libpq-dev
 
 WORKDIR /app
 COPY requirements-dev.txt requirements-dev.txt


### PR DESCRIPTION
The psycopg2 package requires some header file which are missing. This PR installs them.