### PR TITLE
BAU: add workaround to fix dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM python:3.10-bullseye
 
 # install git as pip needs to clone fsd_utils
 RUN apt update && apt -yq install git
+# install manually to workaround issue in psycopg2-binary 2.9.5
+RUN pip3 install psycopg2-binary --no-binary psycopg2-binary
 
 WORKDIR /app
 COPY requirements-dev.txt requirements-dev.txt


### PR DESCRIPTION
Since `psycopg2-binary` was bumped in https://github.com/communitiesuk/funding-service-design-application-store/pull/97 the app was failing to start up within docker compose with the following error:
```
sqlalchemy.exc.OperationalError: (psycopg2.OperationalError) SCRAM authentication requires libpq version 10 or above
```
Add a workaround to fix this, see https://stackoverflow.com/a/73566004 for context

To test this locally you can run from the docker-runner
```
docker compose build application-store --no-cache && docker compose up application-store
```
and the app should start successfully 