### PR TITLE
FS-1674: remove content logging 

### DIFF
--- a/external_services/models/notification.py
+++ b/external_services/models/notification.py
@@ -28,8 +28,8 @@ class Notification(object):
             "content": content,
         }
         current_app.logger.info(
-            f"Sending application to notification service. endpoint: '{url}',"
-            f" json payload: '{template_type} to: {to_email}'."
+            f"Sending application to notification service. endpoint '{url}',"
+            f" json payload '{template_type}' to '{to_email}'."
         )
         response = post_data(url, json_payload)
 

--- a/external_services/models/notification.py
+++ b/external_services/models/notification.py
@@ -29,7 +29,7 @@ class Notification(object):
         }
         current_app.logger.info(
             f"Sending application to notification service. endpoint: '{url}',"
-            f" json payload: '{json_payload}'."
+            f" json payload: '{template_type} to: {to_email}'."
         )
         response = post_data(url, json_payload)
 


### PR DESCRIPTION
With the nested log message in content we got an exception in the logging library:

```
   2022-12-09T16:52:26.28+0000 [APP/TASK/reminder_email/0] ERR log_record["message"] = log_record["message"].format(
   2022-12-09T16:52:26.28+0000 [APP/TASK/reminder_email/0] ERR ValueError: Max string recursion exceeded
   2022-12-09T16:52:26.28+0000 [APP/TASK/reminder_email/0] ERR Call stack:
   2022-12-09T16:52:26.28+0000 [APP/TASK/reminder_email/0] ERR File "/home/vcap/app/./scripts/send_application_reminder.py", line 98, in <module>
```
Fix by no longer logging the full application contents.