### PR TITLE
BAU - Add env var for Assessment e2e test

### DIFF
--- a/.github/workflows/manual-dev-deploy.yaml
+++ b/.github/workflows/manual-dev-deploy.yaml
@@ -48,6 +48,7 @@
         e2e_tests_target_url_frontend: https://fsd:fsd@frontend.dev.gids.dev
         e2e_tests_target_url_authenticator: https://fsd:fsd@authenticator2.dev.gids.dev
         e2e_tests_target_url_form_runner: https://fsd:fsd@forms.dev.gids.dev
+        e2e_tests_target_url_assessment: https://fsd:fsd@assessment.dev.gids.dev
         run_performance_tests: true
         run_e2e_tests: true
       secrets:


### PR DESCRIPTION
### Change description

Added environment var for the Assessment url, so that the assessment e2e test doesn't fail to run in the pipeline.

### How to test
N/A


### Screenshots of UI changes (if applicable)
N/A
