### PR TITLE
Revert "Bump flask-sqlalchemy from 2.5.1 to 3.0.3 (#134)"

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -101,7 +101,7 @@ flask-migrate==4.0.0
     # via -r requirements.txt
 flask-restx==1.0.3
     # via -r requirements.txt
-flask-sqlalchemy==3.0.3
+flask-sqlalchemy==2.5.1
     # via
     #   -r requirements.txt
     #   flask-migrate

--- a/requirements.in
+++ b/requirements.in
@@ -14,7 +14,7 @@ colored
 #   Database
 #-----------------------------------
 SQLAlchemy
-Flask-SQLAlchemy==3.0.3
+Flask-SQLAlchemy==2.5.1
 Flask-Migrate
 sqlalchemy-utils
 sqlalchemy_json

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ flask-migrate==4.0.0
     # via -r requirements.in
 flask-restx==1.0.3
     # via -r requirements.in
-flask-sqlalchemy==3.0.3
+flask-sqlalchemy==2.5.1
     # via
     #   -r requirements.in
     #   flask-migrate


### PR DESCRIPTION
This reverts commit 2bb0c4f7b00ddea1680ccf76a535548697032c4f.

The version bump of flask-sqlalchemy from 2.5.1 to 3.x.x causes the unit tests to fail, this need investigating and fixing.
https://digital.dclg.gov.uk/jira/browse/FS-2382