### PR TITLE
FS-2382-flask-sqlalchemy-version-bump-fix-for-pytest

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -80,6 +80,8 @@ deepdiff==6.2.3
     # via -r requirements-dev.in
 distlib==0.3.6
     # via virtualenv
+exceptiongroup==1.1.0
+    # via pytest
 filelock==3.8.0
     # via virtualenv
 flask==2.2.2
@@ -101,7 +103,7 @@ flask-migrate==4.0.0
     # via -r requirements.txt
 flask-restx==1.0.3
     # via -r requirements.txt
-flask-sqlalchemy==2.5.1
+flask-sqlalchemy==3.0.3
     # via
     #   -r requirements.txt
     #   flask-migrate
@@ -305,6 +307,10 @@ ruamel-yaml==0.17.21
     # via
     #   -r requirements.txt
     #   prance
+ruamel-yaml-clib==0.2.7
+    # via
+    #   -r requirements.txt
+    #   ruamel-yaml
 semver==2.13.0
     # via
     #   -r requirements.txt
@@ -342,6 +348,12 @@ swagger-ui-bundle==0.0.9
     # via -r requirements.txt
 toml==0.10.2
     # via pre-commit
+tomli==2.0.1
+    # via
+    #   black
+    #   build
+    #   pep517
+    #   pytest
 typing-extensions==4.4.0
     # via
     #   -r requirements.txt

--- a/requirements.in
+++ b/requirements.in
@@ -14,7 +14,7 @@ colored
 #   Database
 #-----------------------------------
 SQLAlchemy
-Flask-SQLAlchemy==2.5.1
+Flask-SQLAlchemy==3.0.3
 Flask-Migrate
 sqlalchemy-utils
 sqlalchemy_json

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ flask-migrate==4.0.0
     # via -r requirements.in
 flask-restx==1.0.3
     # via -r requirements.in
-flask-sqlalchemy==2.5.1
+flask-sqlalchemy==3.0.3
     # via
     #   -r requirements.in
     #   flask-migrate
@@ -159,6 +159,8 @@ rich==12.6.0
     # via funding-service-design-utils
 ruamel-yaml==0.17.21
     # via prance
+ruamel-yaml-clib==0.2.7
+    # via ruamel-yaml
 semver==2.13.0
     # via prance
 sentry-sdk[flask]==1.11.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,7 @@ def _transaction(request, _db):
     transaction = connection.begin()
 
     options = dict(bind=connection, binds={})
+    # create a session with "_make_scoped_session"
     session = _db._make_scoped_session(options=options)
 
     def teardown():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,10 @@
 import pytest
 from app import create_app
 from db import db
+from flask import Response
 from flask_migrate import upgrade
 from tests.helpers import local_api_call
-from flask import Response
+
 
 @pytest.fixture(scope="session")
 def app():
@@ -16,6 +17,76 @@ def app():
     with app.app_context():
         upgrade()
     return app
+
+
+@pytest.fixture(scope="session")
+def _db(app):
+    """
+    Provide the transactional fixtures with access
+    to the database via a Flask-SQLAlchemy
+    database connection.
+    """
+    return db
+
+
+@pytest.fixture(scope="function")
+def _transaction(request, _db):
+    """
+    Overrides the default pytest-flask-sqlalchemy fixture `_transaction`
+    due to issues with the recent upgrade from version 2.5.1 to 3.0.3.
+    Provides a transactional database session with a connection,
+    transaction and session objects.
+
+    Args:
+    request: the pytest request object.
+    _db: the pytest fixture that provides access to the database.
+
+    return: a tuple containing the connection, transaction
+    and session objects.
+    """
+    connection = _db.engine.connect()
+    transaction = connection.begin()
+
+    options = dict(bind=connection, binds={})
+    session = _db._make_scoped_session(options=options)
+
+    def teardown():
+        transaction.rollback()
+        connection.close()
+        session.remove()
+
+    request.addfinalizer(teardown)
+
+    return connection, transaction, session
+
+
+@pytest.fixture(autouse=True)
+def clear_database(_db):
+    """
+    Fixture to clean up the database after each test.
+
+    This fixture clears the database by deleting all data
+    from tables and disabling foreign key checks before the test,
+    and resetting foreign key checks after the test.
+
+    Args:
+    _db: The database instance.
+    """
+    yield
+
+    with _db.engine.connect() as connection:
+        # disable foreign key checks
+        connection.execute("SET session_replication_role = replica")
+        # delete all data from tables
+        for table in reversed(db.metadata.sorted_tables):
+            connection.execute(table.delete())
+        # reset foreign key checks
+        connection.execute("SET session_replication_role = DEFAULT")
+
+
+@pytest.fixture(autouse=True)
+def enable_transactional_tests(db_session):
+    pass
 
 
 def mock_get_data(endpoint, params=None):
@@ -46,10 +117,14 @@ def mock_random_choices(mocker):
     # mock the function in the file it is invoked (not where it is declared)
     mocker.patch("random.choices", new=mock_get_random_choices)
 
+
 @pytest.fixture()
 def mock_successful_submit_notification(mocker):
     # mock the function in the file it is invoked (not where it is declared)
-    mocker.patch("api.routes.application.routes.Notification.send", lambda template, email, application: Response(200))
+    mocker.patch(
+        "api.routes.application.routes.Notification.send",
+        lambda template, email, application: Response(200),
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -59,18 +134,3 @@ def mock_post_data_fix(mocker):
         "external_services.post_data",
         new=mock_post_data,
     )
-
-
-@pytest.fixture(scope="session")
-def _db(app):
-    """
-    Provide the transactional fixtures with access
-    to the database via a Flask-SQLAlchemy
-    database connection.
-    """
-    return db
-
-
-@pytest.fixture(autouse=True)
-def enable_transactional_tests(db_session):
-    pass


### PR DESCRIPTION
Ticket ; https://digital.dclg.gov.uk/jira/secure/RapidBoard.jspa?rapidView=110&projectKey=FS&view=detail&selectedIssue=FS-2382&quickFilter=542

Description:

**In this PR, we refactored two test fixtures to improve the testing environment for our Flask application.**

First, we refactored the _transaction fixture to override the default SQLAlchemy _transaction fixture that was causing issues with Pytest due to the recent upgrade of Flask-SQLAlchemy from version 2.5.1 to 3.0.3. The new _transaction fixture creates a new session with a new connection and transaction for each test, and cleans up the connection and transaction after each test to ensure isolation between tests.

Second, we added a new fixture called clear_database to clean up the database after each test. This fixture clears all data from the database tables by disabling foreign key checks, deleting all data from the tables, and resetting foreign key checks. This ensures that each test starts with a clean slate and does not interfere with the results of other tests.