### PR TITLE
bau adding vs code launch configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,9 +131,6 @@ dmypy.json
 # IntelliJ
 .idea
 
-# VS Code
-.vscode/
-
 # Mac files
 .bash_profile
 .DS_Store

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,46 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Docker-Runner application-store",
+            "type": "python",
+            "request": "attach",
+            "connect": {
+                "host": "localhost",
+                "port": 5682
+            },
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceFolder}",
+                    "remoteRoot": "."
+                }
+            ],
+            "justMyCode": true
+        },
+        {
+            "name": "Python: Flask",
+            "type": "python",
+            "request": "launch",
+            "module": "flask",
+            "env": {
+                "FLASK_APP": "app.py",
+                "FLASK_ENV": "development"
+            },
+            "args": [
+                "run",
+                "--no-debugger"
+            ],
+            "jinja": true,
+            "justMyCode": true
+        },
+        {
+            "name": "Debug Unit Test",
+            "type": "python",
+            "request": "launch",
+            "justMyCode": false,
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true,
+    "python.linting.flake8Enabled": true,
+    "python.linting.enabled": true
+}


### PR DESCRIPTION
### Change description
Added workspace settings and launch configurations for vs code to make debugging easier and standardise linting

- [n/a] Unit tests and other appropriate tests added or updated
- [n/a] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
- Use VS Code
- Clone this branch
- Checkout the branch https://github.com/communitiesuk/funding-service-design-docker-runner/tree/bau-debug-containers of the docker runner
- Run `docker compose build fund-store` to rebuild this app
- Run `docker compose up fund-store` and run the debug config `Docker-Runner fund-store`. Set a breakpoint in the fund-store and the debugger will allow you to step through.


