### PR TITLE
fs-2740-project-name

### DIFF
--- a/db/queries/application/queries.py
+++ b/db/queries/application/queries.py
@@ -204,11 +204,13 @@ def submit_application(application_id) -> Applications:
 
 
 def update_project_name(form_name, question_json, application) -> None:
-    if form_name in ("project-information", "gwybodaeth-am-y-prosiect"):
+    if form_name.startswith("project-information") or form_name.startswith(
+        "gwybodaeth-am-y-prosiect"
+    ):
         for question in question_json:
             for field in question["fields"]:
                 # field id for project name in json
-                if field["key"] == "KAgrBz":
+                if field["title"] == "Project name":
                     try:
                         application.project_name = field["answer"]
                     except KeyError:


### PR DESCRIPTION
This ticket includes the fix for cof r3w1 where project name was not displayed in the dashboard. This problem was cause due to differently named forms and fields. We have now updated the checks in the update_project_name() function to be more general when looking for an updated project name.
