### PR TITLE
FS-2826 prevent welsh application if fund is english only

### DIFF
--- a/db/queries/application/queries.py
+++ b/db/queries/application/queries.py
@@ -107,6 +107,9 @@ def _create_application_try(
 def create_application(account_id, fund_id, round_id, language) -> Applications:
     fund = get_fund(fund_id)
     fund_round = get_round(fund_id, round_id)
+    application_start_language = language
+    if language == "cy" and not fund.welsh_available:
+        application_start_language = "en"
     if fund and fund_round and fund.short_name and fund_round.short_name:
         new_application = None
         max_tries = 10
@@ -120,7 +123,7 @@ def create_application(account_id, fund_id, round_id, language) -> Applications:
                 fund_id=fund_id,
                 round_id=round_id,
                 key=key,
-                language=language,
+                language=application_start_language,
                 reference="-".join([fund.short_name, fund_round.short_name, key]),
                 attempt=attempt,
             )

--- a/external_services/models/fund.py
+++ b/external_services/models/fund.py
@@ -12,6 +12,7 @@ class Fund:
     identifier: str
     short_name: str
     description: str
+    welsh_available: bool
     rounds: Optional[List[Round]] = None
 
     @staticmethod
@@ -22,6 +23,7 @@ class Fund:
                 identifier=data["id"],
                 short_name=data["short_name"],
                 description=data["description"],
+                welsh_available=data["welsh_available"],
             )
         except AttributeError as e:
             current_app.logger.error("Empty data passed to Fund.from_json")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -226,7 +226,7 @@ def mock_get_random_choices(population, weights=None, *, cum_weights=None, k=1):
 
 
 def generate_mock_fund(fund_id: str) -> Fund:
-    return Fund("Generated test fund", fund_id, "TEST", "Testing fund", [])
+    return Fund("Generated test fund", fund_id, "TEST", "Testing fund", True, [])
 
 
 @pytest.fixture(scope="function", autouse=True)


### PR DESCRIPTION
### Change description
As not all funds support welsh, we need to ensure that even if a user has welsh selected as their frontend language (eg. from the all funds dashboard) they cannot start an application in welsh if the fund does not support it.

- [X] Unit tests and other appropriate tests added or updated
- [n/a] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
1. Pull this branch, plus the below branches of other repos and run in docker-runner. 
2. Make sure COF and NS data are in the DB. 
3. Login to the service and go to the 'View all applications' link at the top. 
4. Switch to Welsh
5. Scroll down to Night Shelter and click 'view applications from all rounds/windows'
6. The page should display in Welsh. Start a new applicaiton.
7. The application should be started in English.

Linked branches:
- https://github.com/communitiesuk/funding-service-design-fund-store/tree/fs-2815-ns-config
- https://github.com/communitiesuk/funding-service-design-application-store/tree/fs-2826-welsh-optional
- https://github.com/communitiesuk/funding-service-design-frontend/tree/fs-2826-welsh-optional

### Screenshots of UI changes (if applicable)
N/A