### PR TITLE
FS-2842: Get filenames during submission

### DIFF
--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -1,5 +1,7 @@
 """Flask configuration."""
+import json
 import logging
+import os
 from os import environ
 from pathlib import Path
 
@@ -43,6 +45,16 @@ class DefaultConfig:
         "NOTIFY_TEMPLATE_APPLICATION_DEADLINE_REMINDER",
         NOTIFY_TEMPLATE_APPLICATION_DEADLINE_REMINDER,
     )
+
+    if "VCAP_SERVICES" in os.environ:
+        vcap_services = json.loads(os.environ["VCAP_SERVICES"])
+
+        if "aws-s3-bucket" in vcap_services:
+            s3_credentials = vcap_services["aws-s3-bucket"][0]["credentials"]
+            AWS_REGION = s3_credentials["aws_region"]
+            AWS_ACCESS_KEY_ID = s3_credentials["aws_access_key_id"]
+            AWS_SECRET_ACCESS_KEY = s3_credentials["aws_secret_access_key"]
+            AWS_BUCKET_NAME = s3_credentials["bucket_name"]
 
     # Account Store Endpoints
     ACCOUNTS_ENDPOINT = "/accounts"

--- a/config/envs/unit_testing.py
+++ b/config/envs/unit_testing.py
@@ -1,5 +1,6 @@
 # flake8 : noqa
 """Flask Unit Testing Environment Configuration."""
+import os
 from os import environ
 
 from config.envs.default import DefaultConfig
@@ -26,3 +27,8 @@ class UnitTestingConfig(DefaultConfig):
     SQLALCHEMY_TRACK_MODIFICATIONS = False
 
     USE_LOCAL_DATA = True
+
+    AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID")
+    AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY")
+    AWS_BUCKET_NAME = os.environ.get("AWS_BUCKET_NAME")
+    AWS_REGION = os.environ.get("AWS_REGION")

--- a/db/queries/application/queries.py
+++ b/db/queries/application/queries.py
@@ -203,7 +203,7 @@ def submit_application(application_id) -> Applications:
     application.date_submitted = datetime.now(timezone.utc).isoformat()
 
     all_application_files = list_files_by_prefix(application_id)
-    process_files(application, all_application_files)
+    application = process_files(application, all_application_files)
 
     application.status = "SUBMITTED"
     db.session.commit()

--- a/db/queries/application/queries.py
+++ b/db/queries/application/queries.py
@@ -14,6 +14,7 @@ from db.models.application.enums import Status as ApplicationStatus
 from db.schemas import ApplicationSchema
 from external_services import get_fund
 from external_services import get_round
+from external_services.aws import FileData
 from external_services.aws import list_files_by_prefix
 from flask import current_app
 from sqlalchemy import func
@@ -201,31 +202,25 @@ def submit_application(application_id) -> Applications:
     application = get_application(application_id)
     application.date_submitted = datetime.now(timezone.utc).isoformat()
 
-    current_app.logger.info(
-        "Grabbing file upload states from relevant s3 component directories"
-    )
-    file_upload_states = list_files_by_prefix(application_id)
-
-    grouped_states_by_component_id = {}
-    for key, group in groupby(file_upload_states, key=lambda x: x.component_id):
-        grouped_states_by_component_id[key] = list(group)
-
-    for form in application.forms:
-        for component in form.json:
-            for field in component["fields"]:
-                component_id = field["key"]
-                if component_id not in grouped_states_by_component_id:
-                    continue
-
-                component_file_upload_states = grouped_states_by_component_id[
-                    component_id
-                ]
-                field["answer"] = ", ".join(
-                    state.filename for state in component_file_upload_states
-                )
+    all_application_files = list_files_by_prefix(application_id)
+    process_files(application, all_application_files)
 
     application.status = "SUBMITTED"
     db.session.commit()
+    return application
+
+
+def process_files(application: Applications, all_files: list[FileData]) -> Applications:
+    comp_id_to_files = {
+        comp_id: list(files)
+        for comp_id, files in groupby(all_files, key=lambda x: x.component_id)
+    }
+    for form in application.forms:
+        for component in form.json:
+            for field in component["fields"]:
+                comp_id = field["key"]
+                if files := comp_id_to_files.get(comp_id):
+                    field["answer"] = ", ".join(state.filename for state in files)
     return application
 
 

--- a/external_services/aws.py
+++ b/external_services/aws.py
@@ -1,0 +1,43 @@
+import contextlib
+from collections import namedtuple
+
+import boto3
+from config import Config
+
+_S3_CLIENT = boto3.client(
+    "s3",
+    aws_access_key_id=Config.AWS_ACCESS_KEY_ID,
+    aws_secret_access_key=Config.AWS_SECRET_ACCESS_KEY,
+    region_name=Config.AWS_REGION,
+)
+
+
+FileData = namedtuple(
+    "FileData", ["application_id", "form", "path", "component_id", "filename"]
+)
+
+
+def list_files_by_prefix(prefix: str) -> list[FileData]:
+    objects_response = _S3_CLIENT.list_objects_v2(
+        Bucket=Config.AWS_BUCKET_NAME,
+        Prefix=prefix,
+    )
+
+    if not objects_response.get("Contents"):
+        return []
+
+    files = []
+    keys = [file["Key"] for file in objects_response["Contents"]]
+    for key in keys:
+        with contextlib.suppress(ValueError):  # if we don't have a valid key, skip it
+            application_id, form, path, component_id, filename = key.split("/")
+            files.append(
+                FileData(
+                    application_id=application_id,
+                    form=form,
+                    path=path,
+                    component_id=component_id,
+                    filename=filename,
+                )
+            )
+    return files

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -1,0 +1,17 @@
+import pytest
+from external_services.aws import list_files_by_prefix
+
+
+# You can use this for testing the function if doing tdd.
+# I will write some proper unit tests later when I have time.
+@pytest.mark.skip()
+def test_list_files_recursive():
+    bucket_name = (  # this is form-uploads-dev
+        "paas-s3-broker-prod-lon-443b9fc2-55ff-4c2f-9ac3-d3ebfb18ef5a"
+    )
+    prefix = (  # this was just a mock application id i used for testing.
+        "my-application-id/"
+    )
+
+    files = list_files_by_prefix(bucket_name, prefix)
+    assert len(files) != 0

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -4,7 +4,7 @@ from external_services.aws import list_files_by_prefix
 
 # You can use this for testing the function if doing tdd.
 @pytest.mark.skip()
-def test_list_files_recursive():
+def test_list_files_tdd():
     bucket_name = (  # this is form-uploads-dev
         "paas-s3-broker-prod-lon-443b9fc2-55ff-4c2f-9ac3-d3ebfb18ef5a"
     )

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -3,15 +3,48 @@ from external_services.aws import list_files_by_prefix
 
 
 # You can use this for testing the function if doing tdd.
-# I will write some proper unit tests later when I have time.
 @pytest.mark.skip()
 def test_list_files_recursive():
     bucket_name = (  # this is form-uploads-dev
         "paas-s3-broker-prod-lon-443b9fc2-55ff-4c2f-9ac3-d3ebfb18ef5a"
     )
-    prefix = (  # this was just a mock application id i used for testing.
+    prefix = (  # this was just a mock application id I used for testing.
         "my-application-id/"
     )
 
     files = list_files_by_prefix(bucket_name, prefix)
     assert len(files) != 0
+
+
+def test_list_files_by_prefix_multiple_files(mocker):
+    """
+    GIVEN an S3 objects response with multiple files
+    WHEN calling list_files_by_prefix with a prefix
+    THEN it should return a list of FileData instances with the correct key parts
+    """
+    prefix = "application_id/"
+    objects_response = {
+        "Contents": [
+            {"Key": f"{prefix}form/path/component_id/filename1"},
+            {"Key": f"{prefix}form/path/component_id/filename2"},
+            {
+                "Key": f"{prefix}wrong_path_somehow/filename2"
+            },  # ignored, not enough key parts (this won't happen)
+        ]
+    }
+    mocker.patch(
+        "external_services.aws._S3_CLIENT.list_objects_v2",
+        return_value=objects_response,
+    )
+
+    result = list_files_by_prefix(prefix)
+    assert len(result) == 2
+
+    file1, file2 = result
+    assert file1.application_id == file2.application_id == "application_id"
+    assert file1.component_id == file2.component_id == "component_id"
+    assert file1.form == file2.form == "form"
+    assert file1.path == file2.path == "path"
+
+    assert file1.filename == "filename1"
+    assert file2.filename == "filename2"

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -1,0 +1,164 @@
+import pytest
+from db.models import Applications
+from db.models import Forms
+from db.queries.application import process_files
+from external_services.aws import FileData
+
+
+@pytest.mark.parametrize(
+    "application, all_application_files, expected",
+    [
+        pytest.param(
+            Applications(
+                forms=[
+                    Forms(
+                        json=[
+                            {
+                                "fields": [
+                                    {"key": "not_a_file_component", "answer": None}
+                                ]
+                            }
+                        ]
+                    )
+                ]
+            ),
+            [FileData("app1", "form1", "path1", "component1", "file1.docx")],
+            Applications(
+                forms=[
+                    Forms(
+                        json=[
+                            {
+                                "fields": [
+                                    {"key": "not_a_file_component", "answer": None}
+                                ]
+                            }
+                        ]
+                    )
+                ]
+            ),
+            id="Irrelevant components are ignored",
+        ),
+        pytest.param(
+            Applications(
+                forms=[
+                    Forms(json=[{"fields": [{"key": "component1", "answer": None}]}]),
+                    Forms(json=[{"fields": [{"key": "component2", "answer": None}]}]),
+                ]
+            ),
+            [
+                FileData("app1", "form1", "path1", "component1", "file1.docx"),
+                FileData("app1", "form1", "path1", "component2", "file2.docx"),
+            ],
+            Applications(
+                forms=[
+                    Forms(
+                        json=[
+                            {"fields": [{"key": "component1", "answer": "file1.docx"}]}
+                        ]
+                    ),
+                    Forms(
+                        json=[
+                            {"fields": [{"key": "component2", "answer": "file2.docx"}]}
+                        ]
+                    ),
+                ]
+            ),
+            id="Multiple forms all work as expected",
+        ),
+        pytest.param(
+            Applications(
+                forms=[
+                    Forms(json=[{"fields": [{"key": "component1", "answer": None}]}])
+                ]
+            ),
+            [FileData("app1", "form1", "path1", "component1", "file1.docx")],
+            Applications(
+                forms=[
+                    Forms(
+                        json=[
+                            {"fields": [{"key": "component1", "answer": "file1.docx"}]}
+                        ]
+                    )
+                ]
+            ),
+            id="Single file available for a component",
+        ),
+        pytest.param(
+            Applications(
+                forms=[
+                    Forms(json=[{"fields": [{"key": "component1", "answer": None}]}])
+                ]
+            ),
+            [
+                FileData("app1", "form1", "path1", "component1", "file1.docx"),
+                FileData("app1", "form1", "path2", "component1", "file2.pdf"),
+                FileData("app1", "form1", "path3", "component1", "file3.txt"),
+            ],
+            Applications(
+                forms=[
+                    Forms(
+                        json=[
+                            {
+                                "fields": [
+                                    {
+                                        "key": "component1",
+                                        "answer": "file1.docx, file2.pdf, file3.txt",
+                                    }
+                                ]
+                            }
+                        ]
+                    )
+                ]
+            ),
+            id="Multiple files available for a component",
+        ),
+        pytest.param(
+            Applications(
+                forms=[
+                    Forms(
+                        json=[
+                            {
+                                "fields": [
+                                    {"key": "component1", "answer": None},
+                                    {"key": "component2", "answer": None},
+                                ]
+                            }
+                        ]
+                    )
+                ]
+            ),
+            [
+                FileData("app1", "form1", "path1", "component1", "file1.docx"),
+                FileData("app1", "form1", "path2", "component1", "file2.pdf"),
+                FileData("app1", "form1", "path3", "component2", "file3.txt"),
+            ],
+            Applications(
+                forms=[
+                    Forms(
+                        json=[
+                            {
+                                "fields": [
+                                    {
+                                        "key": "component1",
+                                        "answer": "file1.docx, file2.pdf",
+                                    },
+                                    {"key": "component2", "answer": "file3.txt"},
+                                ]
+                            }
+                        ]
+                    )
+                ]
+            ),
+            id="Files available for multiple components",
+        ),
+    ],
+)
+def test_process_files(application, all_application_files, expected):
+    """
+    GIVEN an application object and a list of all files belonging to that application
+    WHEN the process_files function is invoked with these parameters
+    THEN the application object is expected to be updated with the relevant file information
+    """
+    result = process_files(application, all_application_files)
+    for form, expected_form in zip(result.forms, expected.forms):
+        assert form.json == pytest.approx(expected_form.json)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -512,7 +512,9 @@ def test_successful_submitted_application(
     WHEN an application is submitted
     THEN a 201 response is received in the correct format
     """
-    mocker.patch("db.queries.list_files_by_prefix", new=lambda _: [])
+    mocker.patch(
+        "db.queries.application.queries.list_files_by_prefix", new=lambda _: []
+    )
     seed_application_records[0].status = "SUBMITTED"
 
     _db.session.add(seed_application_records[0])

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -504,7 +504,7 @@ def test_put_returns_400_on_submitted_application(
 
 @pytest.mark.apps_to_insert([test_application_data[0]])
 def test_successful_submitted_application(
-    client, mock_successful_submit_notification, _db, seed_application_records
+    client, mock_successful_submit_notification, _db, seed_application_records, mocker
 ):
 
     """
@@ -512,6 +512,7 @@ def test_successful_submitted_application(
     WHEN an application is submitted
     THEN a 201 response is received in the correct format
     """
+    mocker.patch("db.queries.list_files_by_prefix", new=lambda _: [])
     seed_application_records[0].status = "SUBMITTED"
 
     _db.session.add(seed_application_records[0])


### PR DESCRIPTION
### Change description
- Add skipped test for TDD
- Add aws file for getting file metadata
- When submitting application, grab the & commit

---

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines

### How to test

Fill out and submit an application! 
Download the text file emailed to you, and the filename(s) should now be visible!

### Screenshots of UI changes (if applicable)

![image](https://github.com/communitiesuk/funding-service-design-application-store/assets/117724519/5d6b870d-cf20-4912-9492-aa84dbd25fe4)

