### PR TITLE
add support to pick up based on project name fund config plus testing

### DIFF
--- a/db/queries/application/queries.py
+++ b/db/queries/application/queries.py
@@ -227,14 +227,13 @@ def process_files(application: Applications, all_files: list[FileData]) -> Appli
     return application
 
 
-def update_project_name(form_name, question_json, application) -> None:
-    if form_name.startswith("project-information") or form_name.startswith(
-        "gwybodaeth-am-y-prosiect"
-    ):
+def update_project_name(form_name, question_json, application, project_name_field_id = None) -> None:
+    forms_containing_project_name = ["project-information", "gwybodaeth-am-y-prosiect", "name-your-application"]
+    if any(form_name.startswith(item) for item in forms_containing_project_name):
         for question in question_json:
             for field in question["fields"]:
                 # field id for project name in json
-                if field["title"] == "Project name":
+                if field["title"] == "Project name" or field["key"] == project_name_field_id:
                     try:
                         application.project_name = field["answer"]
                     except KeyError:

--- a/db/queries/updating/queries.py
+++ b/db/queries/updating/queries.py
@@ -5,6 +5,7 @@ from db.queries.application import get_application
 from db.queries.application import update_project_name
 from db.queries.form import get_form
 from db.queries.statuses import update_statuses
+from external_services import get_round
 from flask import abort
 from flask import current_app
 from sqlalchemy import func
@@ -23,7 +24,8 @@ def update_application_and_related_form(
 
     application.last_edited = func.now()
     form_sql_row = get_form(application_id, form_name)
-    update_project_name(form_name, question_json, application)
+    project_name_field_id = get_round(application.fund_id, application.round_id).project_name_field_id
+    update_project_name(form_name, question_json, application, project_name_field_id)
     form_sql_row.json = question_json
     update_statuses(application_id, form_name, is_summary_page_submit)
     db.session.commit()

--- a/external_services/models/round.py
+++ b/external_services/models/round.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Optional
 
 
 @dataclass
@@ -10,6 +11,7 @@ class Round:
     opens: str
     title: str
     short_name: str
+    project_name_field_id: Optional[str] = None
 
     @staticmethod
     def from_json(data: dict):
@@ -21,4 +23,5 @@ class Round:
             opens=data["opens"],
             deadline=data["deadline"],
             assessment_deadline=data["assessment_deadline"],
+            project_name_field_id=data.get("project_name_field_id", None)
         )

--- a/tests/api_data/get_endpoint_data.json
+++ b/tests/api_data/get_endpoint_data.json
@@ -263,7 +263,8 @@
                 "name": "Added value to the community",
                 "value": 0.10
             }
-        ]
+      ],
+    "project_name_field_id":"KAgrBz"
   },
   "fund_store/funds/fund-b/rounds/summer": {
     "fund_id": "funding-service-design",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -170,7 +170,7 @@ def add_org_data_for_reports(application, unique_append, client):
 
 @pytest.fixture(scope="function")
 def seed_data_multiple_funds_rounds(
-    request, app, clear_test_data, enable_preserve_test_data, client
+    request, mocker, app, clear_test_data, enable_preserve_test_data, client
 ):
     """
     Alternative to seed_application_records above that allows you to specify
@@ -184,6 +184,7 @@ def seed_data_multiple_funds_rounds(
         application_ids: [111, 222])])]}
     """
     marker = request.node.get_closest_marker("fund_round_config")
+    mocker.patch("db.queries.updating.queries.get_round", new=generate_mock_round)
     if marker is None:
         config = {"funds": [{"rounds": [{"applications": [test_application_data[0]]}]}]}
     else:
@@ -257,7 +258,7 @@ def generate_mock_round(fund_id: str, round_id: str) -> Round:
         deadline=datetime.strptime("2023-01-31 12:00:00", "%Y-%m-%d %H:%M:%S"),
         assessment_deadline=datetime.strptime(
             "2023-03-31 12:00:00", "%Y-%m-%d %H:%M:%S"
-        ),
+        )
     )
 
 

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -69,6 +69,7 @@ def test_get_application_statuses_query_param(
     round_idx,
     expected_in_progress,
     client,
+    mock_get_round,
     seed_data_multiple_funds_rounds,
 ):
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -482,6 +482,48 @@ def test_update_project_name_of_application(client, seed_application_records):
 
 
 @pytest.mark.apps_to_insert([test_application_data[0]])
+def test_update_project_name_of_application_driven_by_fund_config(client, seed_application_records):
+    """
+    GIVEN We have a functioning Application Store API
+    WHEN a put is made into the 'project information' section
+     containing a project key specified in fund configuration
+    THEN the project name should be updated on the application.
+    """
+    old_project_name = seed_application_records[0].project_name
+    new_project_name = "updated by unit test"
+    form_name = "project-information"
+    section_put = {
+        "questions": [
+            {
+                "question": "About your project",
+                "fields": [
+                    {
+                        "key": "KAgrBz",
+                        "title": "Rely on field key",
+                        "type": "text",
+                        "answer": new_project_name,
+                    },
+                ],
+            },
+        ],
+        "metadata": {
+            "application_id": str(seed_application_records[0].id),
+            "form_name": form_name,
+        },
+    }
+    client.put(
+        "/applications/forms",
+        json=section_put,
+        follow_redirects=True,
+    )
+    updated_project_name = get_row_by_pk(
+        Applications, seed_application_records[0].id
+    ).project_name
+    assert updated_project_name == new_project_name
+    assert updated_project_name != old_project_name
+
+
+@pytest.mark.apps_to_insert([test_application_data[0]])
 def test_complete_form(client, seed_application_records):
     """
     GIVEN We have a functioning Application Store API


### PR DESCRIPTION
https://digital.dclg.gov.uk/jira/browse/FS-2833

### Change description
Project name has been added as a new form with a new field id. This field_id can be added to a funds configuration, then we can search for this pre-configured field_id to obtain the project name.

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
pytest added


### Screenshots of UI changes (if applicable)
<img width="1067" alt="Pasted Graphic" src="https://github.com/communitiesuk/funding-service-design-application-store/assets/95699325/b09fba72-5e47-4da3-857e-afd2ea6bd968">
