### PR TITLE
Patch: add nstf org-name field to report mapping

### DIFF
--- a/db/queries/reporting/queries.py
+++ b/db/queries/reporting/queries.py
@@ -78,7 +78,7 @@ KEY_REPORT_MAPPING = [
     {
         "form_name": "organisation-information-ns",
         "key": "opFJRm",
-        "return_field": "organisation_name_ns",
+        "return_field": "organisation_name_nstf",
     }
 ]
 

--- a/db/queries/reporting/queries.py
+++ b/db/queries/reporting/queries.py
@@ -79,7 +79,7 @@ KEY_REPORT_MAPPING = [
         "form_name": "organisation-information-ns",
         "key": "opFJRm",
         "return_field": "organisation_name_nstf",
-    }
+    },
 ]
 
 

--- a/db/queries/reporting/queries.py
+++ b/db/queries/reporting/queries.py
@@ -75,6 +75,11 @@ KEY_REPORT_MAPPING = [
         "key": "jLIgoi",
         "return_field": "revenue",
     },
+    {
+        "form_name": "organisation-information-ns",
+        "key": "opFJRm",
+        "return_field": "organisation_name_ns",
+    }
 ]
 
 

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -149,7 +149,7 @@ def test_get_applications_report(
     assert 2 == len(lines)
     assert (
         "eoi_reference,organisation_name,organisation_type,asset_type,"
-        + "geography,capital,revenue"
+        + "geography,capital,revenue,organisation_name_ns"
     ) == lines[0].decode("utf-8")
     fields = lines[1].decode("utf-8").split(",")
     assert expected_org_name == fields[1]
@@ -179,15 +179,15 @@ def test_get_applications_report_query_param(client, seed_data_multiple_funds_ro
     assert (
         line1
         == "eoi_reference,organisation_name,organisation_type,asset_type,"
-        "geography,capital,revenue"
+        "geography,capital,revenue,organisation_name_ns"
     )
 
-    field1, field2, _, _, field5, _, _ = line2.split(",")
+    field1, field2, _, _, field5, _, _, _ = line2.split(",")
     assert field1 == "Test Reference Number"
     assert field2.startswith("Test Org Name ")
     assert field5 == "W1A 1AA"
 
-    field1, field2, _, _, field5, _, _ = line3.split(",")
+    field1, field2, _, _, field5, _, _, _ = line3.split(",")
     assert field1 == "Test Reference Number Welsh"
     assert field2.startswith("Test Org Name 2cy")
     assert field5 == "CF10 3NQ"

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -149,7 +149,7 @@ def test_get_applications_report(
     assert 2 == len(lines)
     assert (
         "eoi_reference,organisation_name,organisation_type,asset_type,"
-        + "geography,capital,revenue,organisation_name_ns"
+        + "geography,capital,revenue,organisation_name_nstf"
     ) == lines[0].decode("utf-8")
     fields = lines[1].decode("utf-8").split(",")
     assert expected_org_name == fields[1]
@@ -179,7 +179,7 @@ def test_get_applications_report_query_param(client, seed_data_multiple_funds_ro
     assert (
         line1
         == "eoi_reference,organisation_name,organisation_type,asset_type,"
-        "geography,capital,revenue,organisation_name_ns"
+        "geography,capital,revenue,organisation_name_nstf"
     )
 
     field1, field2, _, _, field5, _, _, _ = line2.split(",")


### PR DESCRIPTION
https://digital.dclg.gov.uk/jira/browse/FS-2981

### Change description
Patch to allow the retirval of nstf organisation name when running the reports

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
pytest

