### PR TITLE
BAU: Add option to not send notification when submitting

### DIFF
--- a/api/routes/application/routes.py
+++ b/api/routes/application/routes.py
@@ -141,6 +141,10 @@ class ApplicationsView(MethodView):
             return {"code": 404, "message": str(e)}, 404
 
     def submit(self, application_id):
+        should_send_email = True
+        if request.args.get("dont_send_email") == "true":
+            should_send_email = False
+
         try:
             fund_id = get_fund_id(application_id)
             fund_data = get_fund(fund_id)
@@ -157,14 +161,15 @@ class ApplicationsView(MethodView):
                 "fund_name": fund_name,
             }
 
-            Notification.send(
-                Config.NOTIFY_TEMPLATE_SUBMIT_APPLICATION,
-                account.email,
-                {
-                    NotifyConstants.APPLICATION_FIELD: application_with_form_json_and_fund_name,
-                    NotifyConstants.MAGIC_LINK_CONTACT_HELP_EMAIL_FIELD: round_data.contact_email,
-                },
-            )
+            if should_send_email:
+                Notification.send(
+                    Config.NOTIFY_TEMPLATE_SUBMIT_APPLICATION,
+                    account.email,
+                    {
+                        NotifyConstants.APPLICATION_FIELD: application_with_form_json_and_fund_name,
+                        NotifyConstants.MAGIC_LINK_CONTACT_HELP_EMAIL_FIELD: round_data.contact_email,
+                    },
+                )
             return {
                 "id": application_id,
                 "reference": application_with_form_json["reference"],

--- a/openapi/api.yml
+++ b/openapi/api.yml
@@ -198,6 +198,12 @@ paths:
           schema:
             type: string
             format: path
+        - name: dont_send_email
+          in: query
+          required: false
+          description: Whether to send an email notification for the submitted application
+          schema:
+            type: boolean
       responses:
         201:
           description: Application has been submitted successfully


### PR DESCRIPTION
### Change description

- Add option `dont_send_email` to the `submit` application endpoint
- By default is `True` as we should be sending emails
- However, if we force submit, sometimes we may not want to send the email, so good to have the option

---

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines
