### PR TITLE
FS-3331 adding json format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,8 @@ repos:
       - id: reorder-python-imports
         name: Reorder Python imports (src, tests)
         args: ["--application-directories", "src"]
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v3.10.1
+    hooks:
+    -   id: pyupgrade
+        args: ["--py39-plus"]

--- a/api/routes/application/routes.py
+++ b/api/routes/application/routes.py
@@ -16,6 +16,7 @@ from db.queries import get_report_for_applications
 from db.queries import search_applications
 from db.queries import submit_application
 from db.queries import update_form
+from db.queries.reporting.queries import export_application_statuses_to_csv
 from external_services import get_account
 from external_services import get_fund
 from external_services import get_round
@@ -104,7 +105,7 @@ class ApplicationsView(MethodView):
             return {"metrics": report_data}
         else:
             return send_file(
-                export_json_to_csv(report_data),
+                export_application_statuses_to_csv(report_data),
                 "text/csv",
                 as_attachment=True,
                 download_name="required_data.csv",

--- a/api/routes/application/routes.py
+++ b/api/routes/application/routes.py
@@ -1,4 +1,3 @@
-from typing import List
 from typing import Optional
 
 from _helpers import get_blank_forms
@@ -89,8 +88,8 @@ class ApplicationsView(MethodView):
 
     def get_applications_statuses_report(
         self,
-        round_id: Optional[List] = [],
-        fund_id: Optional[List] = [],
+        round_id: Optional[list] = [],
+        fund_id: Optional[list] = [],
         format: Optional[str] = "csv",
     ):
         try:

--- a/api/routes/application/routes.py
+++ b/api/routes/application/routes.py
@@ -1,3 +1,4 @@
+from typing import List
 from typing import Optional
 
 from _helpers import get_blank_forms
@@ -87,8 +88,8 @@ class ApplicationsView(MethodView):
 
     def get_applications_statuses_report(
         self,
-        round_id: Optional[str] = None,
-        fund_id: Optional[str] = None,
+        round_id: Optional[List] = [],
+        fund_id: Optional[List] = [],
         format: Optional[str] = "csv",
     ):
         try:
@@ -100,7 +101,7 @@ class ApplicationsView(MethodView):
             return {"code": 404, "message": str(e)}, 404
 
         if format.lower() == "json":
-            return report_data
+            return {"metrics": report_data}
         else:
             return send_file(
                 export_json_to_csv(report_data),

--- a/api/routes/application/routes.py
+++ b/api/routes/application/routes.py
@@ -86,22 +86,28 @@ class ApplicationsView(MethodView):
             return {"code": 404, "message": str(e)}, 404
 
     def get_applications_statuses_report(
-        self, round_id: Optional[str] = None, fund_id: Optional[str] = None
+        self,
+        round_id: Optional[str] = None,
+        fund_id: Optional[str] = None,
+        format: Optional[str] = "csv",
     ):
         try:
+            report_data = get_general_status_applications_report(
+                round_id or None,
+                fund_id or None,
+            )
+        except NoResultFound as e:
+            return {"code": 404, "message": str(e)}, 404
+
+        if format.lower() == "json":
+            return report_data
+        else:
             return send_file(
-                export_json_to_csv(
-                    get_general_status_applications_report(
-                        round_id or None,
-                        fund_id or None,
-                    )
-                ),
+                export_json_to_csv(report_data),
                 "text/csv",
                 as_attachment=True,
                 download_name="required_data.csv",
             )
-        except NoResultFound as e:
-            return {"code": 404, "message": str(e)}, 404
 
     def get_key_applications_data_report(
         self,

--- a/db/migrations/env.py
+++ b/db/migrations/env.py
@@ -1,5 +1,3 @@
-from __future__ import with_statement
-
 import logging
 from logging.config import fileConfig
 

--- a/db/queries/application/queries.py
+++ b/db/queries/application/queries.py
@@ -3,8 +3,6 @@ import string
 from datetime import datetime
 from datetime import timezone
 from itertools import groupby
-from typing import Dict
-from typing import List
 from typing import Optional
 
 from db import db
@@ -25,7 +23,7 @@ from sqlalchemy.orm import noload
 from sqlalchemy.sql.expression import Select
 
 
-def get_application(app_id, include_forms=False, as_json=False) -> Dict | Applications:
+def get_application(app_id, include_forms=False, as_json=False) -> dict | Applications:
 
     stmt: Select = select(Applications).filter(Applications.id == app_id)
 
@@ -47,7 +45,7 @@ def get_application(app_id, include_forms=False, as_json=False) -> Dict | Applic
 
 def get_applications(
     filters=[], include_forms=False, as_json=False
-) -> List[Dict] | List[Applications]:
+) -> list[dict] | list[Applications]:
 
     stmt: Select = select(Applications)
 
@@ -144,14 +142,14 @@ def create_application(account_id, fund_id, round_id, language) -> Applications:
         )
 
 
-def get_all_applications() -> List:
+def get_all_applications() -> list:
     application_list = db.session.query(Applications).all()
     return application_list
 
 
 def get_count_by_status(
-    round_ids: Optional[List] = [], fund_ids: Optional[List] = []
-) -> Dict[str, int]:
+    round_ids: Optional[list] = [], fund_ids: Optional[list] = []
+) -> dict[str, int]:
     query = db.session.query(
         Applications.fund_id,
         Applications.round_id,
@@ -171,13 +169,11 @@ def get_count_by_status(
         .all()
     )
     results = []
-    unique_funds = set([f[0] for f in grouped_by_fund_round_result]).union(
-        fund_ids or []
-    )
+    unique_funds = {f[0] for f in grouped_by_fund_round_result}.union(fund_ids or [])
     for fund_id in unique_funds:
-        unique_rounds = set(
+        unique_rounds = {
             row[1] for row in grouped_by_fund_round_result if row[0] == fund_id
-        ).union(round_ids or [])
+        }.union(round_ids or [])
         rounds = []
         for round_id in unique_rounds:
             this_round_statuses = {

--- a/db/queries/application/queries.py
+++ b/db/queries/application/queries.py
@@ -150,7 +150,7 @@ def get_all_applications() -> List:
 
 
 def get_count_by_status(
-    round_ids: Optional[List] = None, fund_ids: Optional[List] = None
+    round_ids: Optional[List] = [], fund_ids: Optional[List] = []
 ) -> Dict[str, int]:
     query = db.session.query(
         Applications.fund_id,
@@ -171,11 +171,13 @@ def get_count_by_status(
         .all()
     )
     results = []
-    unique_funds = set([f[0] for f in grouped_by_fund_round_result])
+    unique_funds = set([f[0] for f in grouped_by_fund_round_result]).union(
+        fund_ids or []
+    )
     for fund_id in unique_funds:
         unique_rounds = set(
             row[1] for row in grouped_by_fund_round_result if row[0] == fund_id
-        )
+        ).union(round_ids or [])
         rounds = []
         for round_id in unique_rounds:
             this_round_statuses = {
@@ -186,7 +188,7 @@ def get_count_by_status(
             rounds.append(
                 {
                     "round_id": round_id,
-                    "metrics": {
+                    "application_statuses": {
                         **{s.name: 0 for s in ApplicationStatus},
                         **this_round_statuses,
                     },

--- a/db/queries/reporting/queries.py
+++ b/db/queries/reporting/queries.py
@@ -9,6 +9,38 @@ from db.queries import get_applications
 from db.queries.application import get_count_by_status
 
 
+APPLICATION_STATUS_HEADERS = [
+    "fund_id",
+    "round_id",
+    "NOT_STARTED",
+    "IN_PROGRESS",
+    "COMPLETED",
+    "SUBMITTED",
+]
+
+
+def export_application_statuses_to_csv(return_data):
+    output = io.StringIO()
+
+    w = csv.DictWriter(output, APPLICATION_STATUS_HEADERS)
+    w.writeheader()
+    for fund in return_data:
+        fund_id = fund["fund_id"]
+        for round in fund["rounds"]:
+            round_id = round["round_id"]
+            w.writerow(
+                {
+                    "fund_id": fund_id,
+                    "round_id": round_id,
+                    **round["application_statuses"],
+                }
+            )
+
+    bytes_object = bytes(output.getvalue(), encoding="utf-8")
+    bytes_output = io.BytesIO(bytes_object)
+    return bytes_output
+
+
 def export_json_to_csv(return_data, headers=None):
     output = io.StringIO()
     if type(return_data) == list:

--- a/db/queries/reporting/queries.py
+++ b/db/queries/reporting/queries.py
@@ -1,7 +1,7 @@
 import csv
 import io
 import re
-from typing import Iterable
+from collections.abc import Iterable
 from typing import Optional
 
 from db.models import Applications

--- a/external_services/aws.py
+++ b/external_services/aws.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from os import getenv
 
 import boto3
 from config import Config
@@ -9,6 +10,7 @@ _S3_CLIENT = boto3.client(
     aws_access_key_id=Config.AWS_ACCESS_KEY_ID,
     aws_secret_access_key=Config.AWS_SECRET_ACCESS_KEY,
     region_name=Config.AWS_REGION,
+    endpoint_url=getenv("AWS_ENDPOINT_OVERRIDE", None),
 )
 
 

--- a/external_services/data.py
+++ b/external_services/data.py
@@ -1,7 +1,6 @@
 import functools
 import json
 import os
-from typing import List
 from typing import Optional
 from urllib.parse import urlencode
 
@@ -91,7 +90,7 @@ def get_application_sections(fund_id, round_id, language):
     return response
 
 
-def get_funds() -> List[Fund] | None:
+def get_funds() -> list[Fund] | None:
     endpoint = Config.FUND_STORE_API_HOST + Config.FUNDS_ENDPOINT
     response = get_data(endpoint)
     if response and len(response) > 0:
@@ -111,7 +110,7 @@ def get_fund(fund_id: str) -> Fund | None:
     return fund
 
 
-def get_rounds(fund_id: str) -> Fund | List:
+def get_rounds(fund_id: str) -> Fund | list:
     endpoint = Config.FUND_STORE_API_HOST + Config.FUND_ROUNDS_ENDPOINT.format(
         fund_id=fund_id
     )

--- a/external_services/http_methods.py
+++ b/external_services/http_methods.py
@@ -1,6 +1,5 @@
 import json
 import os
-from typing import Dict
 from typing import Optional
 
 import requests
@@ -9,7 +8,7 @@ from external_services.exceptions import NotificationError
 from flask import current_app
 
 
-def post_data(endpoint: str, json_payload: Optional[dict] = None) -> Dict:
+def post_data(endpoint: str, json_payload: Optional[dict] = None) -> dict:
 
     if Config.USE_LOCAL_DATA:
         current_app.logger.info(f"Posting to local dummy endpoint: {endpoint}")

--- a/external_services/models/fund.py
+++ b/external_services/models/fund.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import List
 from typing import Optional
 
 from external_services.models.round import Round
@@ -13,7 +12,7 @@ class Fund:
     short_name: str
     description: str
     welsh_available: bool
-    rounds: Optional[List[Round]] = None
+    rounds: Optional[list[Round]] = None
 
     @staticmethod
     def from_json(data: dict):

--- a/external_services/models/notification.py
+++ b/external_services/models/notification.py
@@ -3,7 +3,7 @@ from external_services import post_data
 from flask import current_app
 
 
-class Notification(object):
+class Notification:
     """
     Class for holding Notification operations
     """

--- a/openapi/api.yml
+++ b/openapi/api.yml
@@ -249,17 +249,6 @@ paths:
         - name: format
           in: query
           description: Optional format specifier, csv or json
-          
-        - name: format
-          in: query
-          description: Optional format specifier, csv or json
-          schema:
-            type: array
-            items:
-              type: string
-        - name: format
-          in: query
-          description: Optional format specifier, csv or json
           schema:
             type: string
             enum: [csv,json]

--- a/openapi/api.yml
+++ b/openapi/api.yml
@@ -242,11 +242,19 @@ paths:
           description: Optional fund ID to filter by
           schema:
             type: string
+        - name: format
+          in: query
+          description: Optional format specifier, csv or json
+          schema:
+            type: string
       responses:
         200:
           description: SUCCESS - Here is the status report on applications
           content:
             text/csv: {}
+            application/json:
+              schema:
+                type: object
         404:
           description: ERROR - Could not get report
           content:

--- a/openapi/api.yml
+++ b/openapi/api.yml
@@ -236,12 +236,20 @@ paths:
           in: query
           description: Optional round ID to filter by
           schema:
-            type: string
+            type: array
+            items:
+              type: string
+          # schema:
+          #   type: string
         - name: fund_id
           in: query
           description: Optional fund ID to filter by
           schema:
-            type: string
+            type: array
+            items:
+              type: string
+          # schema:
+          #   type: string
         - name: format
           in: query
           description: Optional format specifier, csv or json

--- a/openapi/api.yml
+++ b/openapi/api.yml
@@ -253,8 +253,14 @@ paths:
         - name: format
           in: query
           description: Optional format specifier, csv or json
+          
+        - name: format
+          in: query
+          description: Optional format specifier, csv or json
           schema:
-            type: string
+            type: array
+            items:
+              type: string
         - name: format
           in: query
           description: Optional format specifier, csv or json

--- a/openapi/api.yml
+++ b/openapi/api.yml
@@ -255,6 +255,11 @@ paths:
           description: Optional format specifier, csv or json
           schema:
             type: string
+        - name: format
+          in: query
+          description: Optional format specifier, csv or json
+          schema:
+            type: string
       responses:
         200:
           description: SUCCESS - Here is the status report on applications

--- a/openapi/api.yml
+++ b/openapi/api.yml
@@ -239,8 +239,6 @@ paths:
             type: array
             items:
               type: string
-          # schema:
-          #   type: string
         - name: fund_id
           in: query
           description: Optional fund ID to filter by
@@ -248,8 +246,6 @@ paths:
             type: array
             items:
               type: string
-          # schema:
-          #   type: string
         - name: format
           in: query
           description: Optional format specifier, csv or json
@@ -266,6 +262,7 @@ paths:
           description: Optional format specifier, csv or json
           schema:
             type: string
+            enum: [csv,json]
       responses:
         200:
           description: SUCCESS - Here is the status report on applications
@@ -273,7 +270,7 @@ paths:
             text/csv: {}
             application/json:
               schema:
-                type: object
+                $ref: 'components.yml#/components/schemas/StatusReport'
         404:
           description: ERROR - Could not get report
           content:

--- a/openapi/components.yml
+++ b/openapi/components.yml
@@ -1,5 +1,35 @@
 components:
   schemas:
+    StatusReport:
+      type: object
+      properties:
+        metrics:
+          type: array
+          items:
+            type: object
+            properties:
+              fund_id:
+                type: string
+              rounds:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    round_id:
+                      type: string
+                    application_statuses:
+                      $ref: '#/components/schemas/ApplicationMetrics'
+    ApplicationMetrics:
+      type: object
+      properties:
+        NOT_STARTED:
+          type: integer
+        IN_PROGRESS:
+          type: integer
+        COMPLETED:
+          type: integer
+        SUBMITTED:
+          type: integer
     Application:
       type: object
       properties:

--- a/openapi/utils.py
+++ b/openapi/utils.py
@@ -1,11 +1,10 @@
 from typing import Any
-from typing import Dict
 
 import prance
 from config import Config
 
 
-def get_bundled_specs(main_file: str) -> Dict[str, Any]:
+def get_bundled_specs(main_file: str) -> dict[str, Any]:
     path_string = Config.FLASK_ROOT + main_file
     parser = prance.ResolvingParser(path_string, strict=False)
     parser.parse()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,7 +2,6 @@ import json
 import os
 import re
 import urllib
-from typing import List
 
 from config import Config
 from deepdiff import DeepDiff
@@ -316,7 +315,7 @@ def post_test_applications(client):
 
 
 def key_list_to_regex(
-    exclude_keys: List[str] = [
+    exclude_keys: list[str] = [
         "id",
         "reference",
         "started_at",

--- a/tests/seed_data/seed_db.py
+++ b/tests/seed_data/seed_db.py
@@ -18,7 +18,6 @@ def seed_in_progress_application(fund_config, round_config, account_id, language
     app = _seed_application(fund_config["id"], round_config["id"], account_id, language)
     with open(
         f"tests/seed_data/{fund_config['short_code']}_{round_config['short_code']}_all_forms.json",
-        "r",
     ) as f:
         ALL_FORMS = json.load(f)
     form = [
@@ -37,7 +36,6 @@ def seed_completed_application(fund_config, round_config, account_id, language):
     app = _seed_application(fund_config["id"], round_config["id"], account_id, language)
     with open(
         f"tests/seed_data/{fund_config['short_code']}_{round_config['short_code']}_all_forms.json",
-        "r",
     ) as f:
         ALL_FORMS = json.load(f)
     for form in ALL_FORMS:

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -2,6 +2,7 @@ import pytest
 from db.models import Applications
 from db.models import Forms
 from db.queries.application import process_files
+from db.queries.reporting.queries import export_application_statuses_to_csv
 from external_services.aws import FileData
 
 
@@ -162,3 +163,111 @@ def test_process_files(application, all_application_files, expected):
     result = process_files(application, all_application_files)
     for form, expected_form in zip(result.forms, expected.forms):
         assert form.json == pytest.approx(expected_form.json)
+
+
+@pytest.mark.parametrize(
+    "data,lines_exp",
+    [
+        (
+            [
+                {
+                    "fund_id": "111",
+                    "rounds": [
+                        {
+                            "round_id": "r1r1r1",
+                            "application_statuses": {
+                                "NOT_STARTED": 1,
+                                "IN_PROGRESS": 2,
+                                "COMPLETED": 3,
+                                "SUBMITTED": 4,
+                            },
+                        }
+                    ],
+                }
+            ],
+            ["111,r1r1r1,1,2,3,4"],
+        ),
+        (
+            [
+                {
+                    "fund_id": "111",
+                    "rounds": [
+                        {
+                            "round_id": "r1r1r1",
+                            "application_statuses": {
+                                "NOT_STARTED": 1,
+                                "IN_PROGRESS": 2,
+                                "COMPLETED": 3,
+                                "SUBMITTED": 4,
+                            },
+                        },
+                        {
+                            "round_id": "r2",
+                            "application_statuses": {
+                                "NOT_STARTED": 2,
+                                "IN_PROGRESS": 3,
+                                "COMPLETED": 4,
+                                "SUBMITTED": 5,
+                            },
+                        },
+                    ],
+                }
+            ],
+            ["111,r1r1r1,1,2,3,4", "111,r2,2,3,4,5"],
+        ),
+        (
+            [
+                {
+                    "fund_id": "f1",
+                    "rounds": [
+                        {
+                            "round_id": "r1",
+                            "application_statuses": {
+                                "NOT_STARTED": 1,
+                                "IN_PROGRESS": 2,
+                                "COMPLETED": 3,
+                                "SUBMITTED": 4,
+                            },
+                        },
+                        {
+                            "round_id": "r2",
+                            "application_statuses": {
+                                "NOT_STARTED": 0,
+                                "IN_PROGRESS": 0,
+                                "COMPLETED": 0,
+                                "SUBMITTED": 4,
+                            },
+                        },
+                    ],
+                },
+                {
+                    "fund_id": "f2",
+                    "rounds": [
+                        {
+                            "round_id": "r1",
+                            "application_statuses": {
+                                "NOT_STARTED": 2,
+                                "IN_PROGRESS": 2,
+                                "COMPLETED": 1,
+                                "SUBMITTED": 6,
+                            },
+                        },
+                    ],
+                },
+            ],
+            ["f1,r1,1,2,3,4", "f1,r2,0,0,0,4", "f2,r1,2,2,1,6"],
+        ),
+    ],
+)
+def test_application_status_csv(data, lines_exp):
+    result = export_application_statuses_to_csv(data)
+    assert result
+    lines = result.readlines()
+    assert (
+        lines[0].decode().strip()
+        == "fund_id,round_id,NOT_STARTED,IN_PROGRESS,COMPLETED,SUBMITTED"
+    )
+    idx = 1
+    for line in lines_exp:
+        assert lines[idx].decode().strip() == line
+        idx += 1

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -345,6 +345,7 @@ def test_get_application_statuses_json_multi_fund(
         + f"format=json&{'&'.join(fund_params)}&{'&'.join(round_params)}"
     )
     response = client.get(url, follow_redirects=True)
+    assert response.status_code == 200
     result = response.json
     assert result
     funds = result["metrics"]

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -39,8 +39,6 @@ user_lang_cy = {
     "language": "cy",
 }
 
-# @pytest.mark.apps_to_insert(test_application_data)
-
 
 @pytest.mark.fund_round_config(
     {
@@ -87,6 +85,94 @@ def test_get_application_statuses_json(client, seed_data_multiple_funds_rounds, 
     assert result["IN_PROGRESS"] == 2
     assert result["SUBMITTED"] == 0
     assert result["COMPLETED"] == 1
+
+
+@pytest.mark.fund_round_config(
+    {
+        "funds": [
+            {
+                "rounds": [
+                    {
+                        "applications": [
+                            {**user_lang_cy},
+                            {**user_lang_cy},
+                            {**user_lang},
+                        ]
+                    },
+                    {
+                        "applications": [
+                            {**user_lang},
+                        ]
+                    },
+                ]
+            },
+            {
+                "rounds": [
+                    {
+                        "applications": [
+                            {**user_lang_cy},
+                            {**user_lang_cy},
+                        ]
+                    }
+                ]
+            },
+        ]
+    }
+)
+@pytest.mark.parametrize(
+    "fund_idx, round_idx, exp_not_started, exp_in_progress, exp_submitted,"
+    " exp_completed",
+    [
+        ([0, 1], [], 0, 5, 0, 1),
+        ([0], [], 0, 3, 0, 1),
+        ([1], [], 0, 2, 0, 0),
+        ([], [0], 0, 2, 0, 1),
+    ],
+)
+def test_get_application_statuses_json_multi_fund(
+    fund_idx,
+    round_idx,
+    exp_not_started,
+    exp_in_progress,
+    exp_submitted,
+    exp_completed,
+    client,
+    seed_data_multiple_funds_rounds,
+    _db,
+):
+    app = get_row_by_pk(Applications, seed_data_multiple_funds_rounds[0][1][0][1][0])
+    app.status = "COMPLETED"
+    _db.session.add(app)
+    _db.session.commit()
+    fund_ids = [seed_data_multiple_funds_rounds[idx][0] for idx in fund_idx]
+    fund_params = ["fund_id=" + str(id) for id in fund_ids]
+    round_ids = [seed_data_multiple_funds_rounds[0][1][idx] for idx in round_idx]
+    round_params = ["round_id=" + str(id) for id in round_ids]
+    url = (
+        "/applications/reporting/applications_statuses_data?"
+        + f"format=json&{'&'.join(fund_params)}&{'&'.join(round_params)}"
+    )
+    response = client.get(url, follow_redirects=True)
+    result = response.json
+    assert result
+    funds = result["metrics"]
+    for fund_id in fund_ids:
+        assert (
+            len([fund["fund_id"] for fund in funds if fund["fund_id"] == fund_id]) == 1
+        )
+        total_ip = 0
+        total_ns = 0
+        total_c = 0
+        total_s = 0
+        for f in funds:
+            total_ns += sum([r["metrics"]["NOT_STARTED"] for r in f["rounds"]])
+            total_ip += sum([r["metrics"]["IN_PROGRESS"] for r in f["rounds"]])
+            total_c += sum([r["metrics"]["COMPLETED"] for r in f["rounds"]])
+            total_s += sum([r["metrics"]["SUBMITTED"] for r in f["rounds"]])
+        assert total_ns == exp_not_started
+        assert total_ip == exp_in_progress
+        assert total_c == exp_completed
+        assert total_s == exp_submitted
 
 
 @pytest.mark.fund_round_config(

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -454,7 +454,7 @@ def test_get_applications_report_query_param(client, seed_data_multiple_funds_ro
     raw_lines = response.data.splitlines()
     assert len(raw_lines) == 3
 
-    line1, line2, line3 = [line.decode("utf-8") for line in response.data.splitlines()]
+    line1, line2, line3 = (line.decode("utf-8") for line in response.data.splitlines())
     assert (
         line1
         == "eoi_reference,organisation_name,organisation_type,asset_type,"

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -11,8 +11,19 @@ def test_get_application_statuses_csv(client, seed_application_records, _db):
         "/applications/reporting/applications_statuses_data",
         follow_redirects=True,
     )
+    lines = response.data.decode("utf-8").split("\r\n")
+    assert lines[0] == "fund_id,round_id,NOT_STARTED,IN_PROGRESS,COMPLETED,SUBMITTED"
     assert (
-        response.data == b"NOT_STARTED,IN_PROGRESS,SUBMITTED,COMPLETED\r\n3,0,0,0\r\n"
+        f"{test_application_data[0]['fund_id']},{test_application_data[0]['round_id']},1,0,0,0"
+        in lines
+    )
+    assert (
+        f"{test_application_data[1]['fund_id']},{test_application_data[1]['round_id']},1,0,0,0"
+        in lines
+    )
+    assert (
+        f"{test_application_data[2]['fund_id']},{test_application_data[2]['round_id']},1,0,0,0"
+        in lines
     )
 
     app = get_row_by_pk(Applications, seed_application_records[0].id)
@@ -24,8 +35,19 @@ def test_get_application_statuses_csv(client, seed_application_records, _db):
         "/applications/reporting/applications_statuses_data",
         follow_redirects=True,
     )
+    lines = response.data.decode("utf-8").split("\r\n")
+    assert lines[0] == "fund_id,round_id,NOT_STARTED,IN_PROGRESS,COMPLETED,SUBMITTED"
     assert (
-        response.data == b"NOT_STARTED,IN_PROGRESS,SUBMITTED,COMPLETED\r\n2,1,0,0\r\n"
+        f"{test_application_data[0]['fund_id']},{test_application_data[0]['round_id']},0,1,0,0"
+        in lines
+    )
+    assert (
+        f"{test_application_data[1]['fund_id']},{test_application_data[1]['round_id']},1,0,0,0"
+        in lines
+    )
+    assert (
+        f"{test_application_data[2]['fund_id']},{test_application_data[2]['round_id']},1,0,0,0"
+        in lines
     )
 
 
@@ -51,59 +73,13 @@ user_lang_cy = {
                             {**user_lang_cy},
                             {**user_lang},
                         ]
-                    }
-                ]
-            },
-        ]
-    }
-)
-def test_get_application_statuses_json(client, seed_data_multiple_funds_rounds, _db):
-    fund = seed_data_multiple_funds_rounds[0]
-    response = client.get(
-        f"/applications/reporting/applications_statuses_data?format=json&fund_id={fund[0]}",
-        follow_redirects=True,
-    )
-    result = response.json
-    assert result
-    assert result["NOT_STARTED"] == 0
-    assert result["IN_PROGRESS"] == 3
-    assert result["SUBMITTED"] == 0
-    assert result["COMPLETED"] == 0
-
-    app = get_row_by_pk(Applications, fund[1][0][1][0])
-    app.status = "COMPLETED"
-    _db.session.add(app)
-    _db.session.commit()
-
-    response = client.get(
-        f"/applications/reporting/applications_statuses_data?format=json&fund_id={fund[0]}",
-        follow_redirects=True,
-    )
-    result = response.json
-    assert result
-    assert result["NOT_STARTED"] == 0
-    assert result["IN_PROGRESS"] == 2
-    assert result["SUBMITTED"] == 0
-    assert result["COMPLETED"] == 1
-
-
-@pytest.mark.fund_round_config(
-    {
-        "funds": [
-            {
-                "rounds": [
-                    {
-                        "applications": [
-                            {**user_lang_cy},
-                            {**user_lang_cy},
-                            {**user_lang},
-                        ]
                     },
                     {
                         "applications": [
                             {**user_lang},
                         ]
                     },
+                    {"applications": []},
                 ]
             },
             {
@@ -126,6 +102,8 @@ def test_get_application_statuses_json(client, seed_data_multiple_funds_rounds, 
         ([0, 1], [], 0, 5, 0, 1),
         ([0], [], 0, 3, 0, 1),
         ([1], [], 0, 2, 0, 0),
+        ([0], [1, 2], 0, 1, 0, 0),
+        ([0], [2], 0, 0, 0, 0),
         ([], [0], 0, 2, 0, 1),
     ],
 )
@@ -146,7 +124,7 @@ def test_get_application_statuses_json_multi_fund(
     _db.session.commit()
     fund_ids = [seed_data_multiple_funds_rounds[idx][0] for idx in fund_idx]
     fund_params = ["fund_id=" + str(id) for id in fund_ids]
-    round_ids = [seed_data_multiple_funds_rounds[0][1][idx] for idx in round_idx]
+    round_ids = [seed_data_multiple_funds_rounds[0][1][idx][0] for idx in round_idx]
     round_params = ["round_id=" + str(id) for id in round_ids]
     url = (
         "/applications/reporting/applications_statuses_data?"
@@ -165,71 +143,22 @@ def test_get_application_statuses_json_multi_fund(
         total_c = 0
         total_s = 0
         for f in funds:
-            total_ns += sum([r["metrics"]["NOT_STARTED"] for r in f["rounds"]])
-            total_ip += sum([r["metrics"]["IN_PROGRESS"] for r in f["rounds"]])
-            total_c += sum([r["metrics"]["COMPLETED"] for r in f["rounds"]])
-            total_s += sum([r["metrics"]["SUBMITTED"] for r in f["rounds"]])
+            total_ns += sum(
+                [r["application_statuses"]["NOT_STARTED"] for r in f["rounds"]]
+            )
+            total_ip += sum(
+                [r["application_statuses"]["IN_PROGRESS"] for r in f["rounds"]]
+            )
+            total_c += sum(
+                [r["application_statuses"]["COMPLETED"] for r in f["rounds"]]
+            )
+            total_s += sum(
+                [r["application_statuses"]["SUBMITTED"] for r in f["rounds"]]
+            )
         assert total_ns == exp_not_started
         assert total_ip == exp_in_progress
         assert total_c == exp_completed
         assert total_s == exp_submitted
-
-
-@pytest.mark.fund_round_config(
-    {
-        "funds": [
-            {"rounds": [{"applications": [{**user_lang_cy}]}]},
-            {
-                "rounds": [
-                    {"applications": [{**user_lang}]},
-                    {"applications": [{**user_lang_cy}, {**user_lang}]},
-                ]
-            },
-        ]
-    }
-)
-@pytest.mark.parametrize(
-    "fund_idx,round_idx,expected_in_progress",
-    [
-        # (None, None, 4),
-        (0, 0, 1),
-        (0, None, 1),
-        (1, 0, 1),
-        (1, 1, 2),
-        (1, None, 3),
-    ],
-)
-def test_get_application_statuses_query_param(
-    fund_idx,
-    round_idx,
-    expected_in_progress,
-    client,
-    seed_data_multiple_funds_rounds,
-):
-
-    fund_id = (
-        seed_data_multiple_funds_rounds[fund_idx].fund_id
-        if fund_idx is not None
-        else ""
-    )
-    round_id = (
-        seed_data_multiple_funds_rounds[fund_idx].round_ids[round_idx][0]
-        if round_idx is not None
-        else ""
-    )
-
-    url = (
-        "/applications/reporting/applications_statuses_data?fund_id="
-        + f"{fund_id}&round_id={round_id}"
-    )
-
-    response = client.get(
-        url,
-    )
-    lines = response.data.splitlines()
-    assert 2 == len(lines)
-    assert lines[0] == b"NOT_STARTED,IN_PROGRESS,SUBMITTED,COMPLETED"
-    assert expected_in_progress == int(lines[1].decode("utf-8").split(",")[1])
 
 
 @pytest.mark.parametrize(

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -21,7 +21,19 @@ def test_get_application_statuses_csv(client, seed_application_records, _db):
         f"{test_application_data[1]['fund_id']},{test_application_data[1]['round_id']},1,0,0,0"
         in lines
     )
+    lines = response.data.decode("utf-8").split("\r\n")
+    assert lines[0] == "fund_id,round_id,NOT_STARTED,IN_PROGRESS,COMPLETED,SUBMITTED"
     assert (
+        f"{test_application_data[0]['fund_id']},{test_application_data[0]['round_id']},1,0,0,0"
+        in lines
+    )
+    assert (
+        f"{test_application_data[1]['fund_id']},{test_application_data[1]['round_id']},1,0,0,0"
+        in lines
+    )
+    assert (
+        f"{test_application_data[2]['fund_id']},{test_application_data[2]['round_id']},1,0,0,0"
+        in lines
         f"{test_application_data[2]['fund_id']},{test_application_data[2]['round_id']},1,0,0,0"
         in lines
     )
@@ -45,7 +57,19 @@ def test_get_application_statuses_csv(client, seed_application_records, _db):
         f"{test_application_data[1]['fund_id']},{test_application_data[1]['round_id']},1,0,0,0"
         in lines
     )
+    lines = response.data.decode("utf-8").split("\r\n")
+    assert lines[0] == "fund_id,round_id,NOT_STARTED,IN_PROGRESS,COMPLETED,SUBMITTED"
     assert (
+        f"{test_application_data[0]['fund_id']},{test_application_data[0]['round_id']},0,1,0,0"
+        in lines
+    )
+    assert (
+        f"{test_application_data[1]['fund_id']},{test_application_data[1]['round_id']},1,0,0,0"
+        in lines
+    )
+    assert (
+        f"{test_application_data[2]['fund_id']},{test_application_data[2]['round_id']},1,0,0,0"
+        in lines
         f"{test_application_data[2]['fund_id']},{test_application_data[2]['round_id']},1,0,0,0"
         in lines
     )
@@ -60,53 +84,6 @@ user_lang_cy = {
     "account_id": "userw",
     "language": "cy",
 }
-
-
-@pytest.mark.fund_round_config(
-    {
-        "funds": [
-            {
-                "rounds": [
-                    {
-                        "applications": [
-                            {**user_lang_cy},
-                            {**user_lang_cy},
-                            {**user_lang},
-                        ]
-                    }
-                ]
-            },
-        ]
-    }
-)
-def test_get_application_statuses_json(client, seed_data_multiple_funds_rounds, _db):
-    fund = seed_data_multiple_funds_rounds[0]
-    response = client.get(
-        f"/applications/reporting/applications_statuses_data?format=json&fund_id={fund[0]}",
-        follow_redirects=True,
-    )
-    result = response.json
-    assert result
-    assert result["NOT_STARTED"] == 0
-    assert result["IN_PROGRESS"] == 3
-    assert result["SUBMITTED"] == 0
-    assert result["COMPLETED"] == 0
-
-    app = get_row_by_pk(Applications, fund[1][0][1][0])
-    app.status = "COMPLETED"
-    _db.session.add(app)
-    _db.session.commit()
-
-    response = client.get(
-        f"/applications/reporting/applications_statuses_data?format=json&fund_id={fund[0]}",
-        follow_redirects=True,
-    )
-    result = response.json
-    assert result
-    assert result["NOT_STARTED"] == 0
-    assert result["IN_PROGRESS"] == 2
-    assert result["SUBMITTED"] == 0
-    assert result["COMPLETED"] == 1
 
 
 @pytest.mark.fund_round_config(
@@ -240,6 +217,8 @@ def test_get_application_statuses_json_multi_fund(
         ([0, 1], [], 0, 5, 0, 1),
         ([0], [], 0, 3, 0, 1),
         ([1], [], 0, 2, 0, 0),
+        ([0], [1, 2], 0, 1, 0, 0),
+        ([0], [2], 0, 0, 0, 0),
         ([], [0], 0, 2, 0, 1),
     ],
 )
@@ -260,7 +239,7 @@ def test_get_application_statuses_json_multi_fund(
     _db.session.commit()
     fund_ids = [seed_data_multiple_funds_rounds[idx][0] for idx in fund_idx]
     fund_params = ["fund_id=" + str(id) for id in fund_ids]
-    round_ids = [seed_data_multiple_funds_rounds[0][1][idx] for idx in round_idx]
+    round_ids = [seed_data_multiple_funds_rounds[0][1][idx][0] for idx in round_idx]
     round_params = ["round_id=" + str(id) for id in round_ids]
     url = (
         "/applications/reporting/applications_statuses_data?"
@@ -279,10 +258,18 @@ def test_get_application_statuses_json_multi_fund(
         total_c = 0
         total_s = 0
         for f in funds:
-            total_ns += sum([r["metrics"]["NOT_STARTED"] for r in f["rounds"]])
-            total_ip += sum([r["metrics"]["IN_PROGRESS"] for r in f["rounds"]])
-            total_c += sum([r["metrics"]["COMPLETED"] for r in f["rounds"]])
-            total_s += sum([r["metrics"]["SUBMITTED"] for r in f["rounds"]])
+            total_ns += sum(
+                [r["application_statuses"]["NOT_STARTED"] for r in f["rounds"]]
+            )
+            total_ip += sum(
+                [r["application_statuses"]["IN_PROGRESS"] for r in f["rounds"]]
+            )
+            total_c += sum(
+                [r["application_statuses"]["COMPLETED"] for r in f["rounds"]]
+            )
+            total_s += sum(
+                [r["application_statuses"]["SUBMITTED"] for r in f["rounds"]]
+            )
         assert total_ns == exp_not_started
         assert total_ip == exp_in_progress
         assert total_c == exp_completed

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -29,36 +29,6 @@ def test_get_application_statuses_csv(client, seed_application_records, _db):
     )
 
 
-@pytest.mark.apps_to_insert(test_application_data)
-def test_get_application_statuses_json(client, seed_application_records, _db):
-    response = client.get(
-        "/applications/reporting/applications_statuses_data?format=json",
-        follow_redirects=True,
-    )
-    result = response.json
-    assert result
-    assert result["NOT_STARTED"] == 3
-    assert result["IN_PROGRESS"] == 0
-    assert result["SUBMITTED"] == 0
-    assert result["COMPLETED"] == 0
-
-    app = get_row_by_pk(Applications, seed_application_records[0].id)
-    app.status = "IN_PROGRESS"
-    _db.session.add(app)
-    _db.session.commit()
-
-    response = client.get(
-        "/applications/reporting/applications_statuses_data?format=json",
-        follow_redirects=True,
-    )
-    result = response.json
-    assert result
-    assert result["NOT_STARTED"] == 2
-    assert result["IN_PROGRESS"] == 1
-    assert result["SUBMITTED"] == 0
-    assert result["COMPLETED"] == 0
-
-
 user_lang = {
     "account_id": "usera",
     "language": "en",
@@ -68,6 +38,55 @@ user_lang_cy = {
     "account_id": "userw",
     "language": "cy",
 }
+
+# @pytest.mark.apps_to_insert(test_application_data)
+
+
+@pytest.mark.fund_round_config(
+    {
+        "funds": [
+            {
+                "rounds": [
+                    {
+                        "applications": [
+                            {**user_lang_cy},
+                            {**user_lang_cy},
+                            {**user_lang},
+                        ]
+                    }
+                ]
+            },
+        ]
+    }
+)
+def test_get_application_statuses_json(client, seed_data_multiple_funds_rounds, _db):
+    fund = seed_data_multiple_funds_rounds[0]
+    response = client.get(
+        f"/applications/reporting/applications_statuses_data?format=json&fund_id={fund[0]}",
+        follow_redirects=True,
+    )
+    result = response.json
+    assert result
+    assert result["NOT_STARTED"] == 0
+    assert result["IN_PROGRESS"] == 3
+    assert result["SUBMITTED"] == 0
+    assert result["COMPLETED"] == 0
+
+    app = get_row_by_pk(Applications, fund[1][0][1][0])
+    app.status = "COMPLETED"
+    _db.session.add(app)
+    _db.session.commit()
+
+    response = client.get(
+        f"/applications/reporting/applications_statuses_data?format=json&fund_id={fund[0]}",
+        follow_redirects=True,
+    )
+    result = response.json
+    assert result
+    assert result["NOT_STARTED"] == 0
+    assert result["IN_PROGRESS"] == 2
+    assert result["SUBMITTED"] == 0
+    assert result["COMPLETED"] == 1
 
 
 @pytest.mark.fund_round_config(

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -61,8 +61,6 @@ user_lang_cy = {
     "language": "cy",
 }
 
-# @pytest.mark.apps_to_insert(test_application_data)
-
 
 @pytest.mark.fund_round_config(
     {
@@ -109,6 +107,186 @@ def test_get_application_statuses_json(client, seed_data_multiple_funds_rounds, 
     assert result["IN_PROGRESS"] == 2
     assert result["SUBMITTED"] == 0
     assert result["COMPLETED"] == 1
+
+
+@pytest.mark.fund_round_config(
+    {
+        "funds": [
+            {
+                "rounds": [
+                    {
+                        "applications": [
+                            {**user_lang_cy},
+                            {**user_lang_cy},
+                            {**user_lang},
+                        ]
+                    },
+                    {
+                        "applications": [
+                            {**user_lang},
+                        ]
+                    },
+                    {"applications": []},
+                ]
+            },
+            {
+                "rounds": [
+                    {
+                        "applications": [
+                            {**user_lang_cy},
+                            {**user_lang_cy},
+                        ]
+                    }
+                ]
+            },
+        ]
+    }
+)
+@pytest.mark.parametrize(
+    "fund_idx, round_idx, exp_not_started, exp_in_progress, exp_submitted,"
+    " exp_completed",
+    [
+        ([0, 1], [], 0, 5, 0, 1),
+        ([0], [], 0, 3, 0, 1),
+        ([1], [], 0, 2, 0, 0),
+        ([0], [1, 2], 0, 1, 0, 0),
+        ([0], [2], 0, 0, 0, 0),
+        ([], [0], 0, 2, 0, 1),
+    ],
+)
+def test_get_application_statuses_json_multi_fund(
+    fund_idx,
+    round_idx,
+    exp_not_started,
+    exp_in_progress,
+    exp_submitted,
+    exp_completed,
+    client,
+    seed_data_multiple_funds_rounds,
+    _db,
+):
+    app = get_row_by_pk(Applications, seed_data_multiple_funds_rounds[0][1][0][1][0])
+    app.status = "COMPLETED"
+    _db.session.add(app)
+    _db.session.commit()
+    fund_ids = [seed_data_multiple_funds_rounds[idx][0] for idx in fund_idx]
+    fund_params = ["fund_id=" + str(id) for id in fund_ids]
+    round_ids = [seed_data_multiple_funds_rounds[0][1][idx] for idx in round_idx]
+    round_params = ["round_id=" + str(id) for id in round_ids]
+    url = (
+        "/applications/reporting/applications_statuses_data?"
+        + f"format=json&{'&'.join(fund_params)}&{'&'.join(round_params)}"
+    )
+    response = client.get(url, follow_redirects=True)
+    result = response.json
+    assert result
+    funds = result["metrics"]
+    for fund_id in fund_ids:
+        assert (
+            len([fund["fund_id"] for fund in funds if fund["fund_id"] == fund_id]) == 1
+        )
+        total_ip = 0
+        total_ns = 0
+        total_c = 0
+        total_s = 0
+        for f in funds:
+            total_ns += sum([r["metrics"]["NOT_STARTED"] for r in f["rounds"]])
+            total_ip += sum([r["metrics"]["IN_PROGRESS"] for r in f["rounds"]])
+            total_c += sum([r["metrics"]["COMPLETED"] for r in f["rounds"]])
+            total_s += sum([r["metrics"]["SUBMITTED"] for r in f["rounds"]])
+        assert total_ns == exp_not_started
+        assert total_ip == exp_in_progress
+        assert total_c == exp_completed
+        assert total_s == exp_submitted
+
+
+@pytest.mark.fund_round_config(
+    {
+        "funds": [
+            {
+                "rounds": [
+                    {
+                        "applications": [
+                            {**user_lang_cy},
+                            {**user_lang_cy},
+                            {**user_lang},
+                        ]
+                    },
+                    {
+                        "applications": [
+                            {**user_lang},
+                        ]
+                    },
+                    {"applications": []},
+                ]
+            },
+            {
+                "rounds": [
+                    {
+                        "applications": [
+                            {**user_lang_cy},
+                            {**user_lang_cy},
+                        ]
+                    }
+                ]
+            },
+        ]
+    }
+)
+@pytest.mark.parametrize(
+    "fund_idx, round_idx, exp_not_started, exp_in_progress, exp_submitted,"
+    " exp_completed",
+    [
+        ([0, 1], [], 0, 5, 0, 1),
+        ([0], [], 0, 3, 0, 1),
+        ([1], [], 0, 2, 0, 0),
+        ([], [0], 0, 2, 0, 1),
+    ],
+)
+def test_get_application_statuses_json_multi_fund(
+    fund_idx,
+    round_idx,
+    exp_not_started,
+    exp_in_progress,
+    exp_submitted,
+    exp_completed,
+    client,
+    seed_data_multiple_funds_rounds,
+    _db,
+):
+    app = get_row_by_pk(Applications, seed_data_multiple_funds_rounds[0][1][0][1][0])
+    app.status = "COMPLETED"
+    _db.session.add(app)
+    _db.session.commit()
+    fund_ids = [seed_data_multiple_funds_rounds[idx][0] for idx in fund_idx]
+    fund_params = ["fund_id=" + str(id) for id in fund_ids]
+    round_ids = [seed_data_multiple_funds_rounds[0][1][idx] for idx in round_idx]
+    round_params = ["round_id=" + str(id) for id in round_ids]
+    url = (
+        "/applications/reporting/applications_statuses_data?"
+        + f"format=json&{'&'.join(fund_params)}&{'&'.join(round_params)}"
+    )
+    response = client.get(url, follow_redirects=True)
+    result = response.json
+    assert result
+    funds = result["metrics"]
+    for fund_id in fund_ids:
+        assert (
+            len([fund["fund_id"] for fund in funds if fund["fund_id"] == fund_id]) == 1
+        )
+        total_ip = 0
+        total_ns = 0
+        total_c = 0
+        total_s = 0
+        for f in funds:
+            total_ns += sum([r["metrics"]["NOT_STARTED"] for r in f["rounds"]])
+            total_ip += sum([r["metrics"]["IN_PROGRESS"] for r in f["rounds"]])
+            total_c += sum([r["metrics"]["COMPLETED"] for r in f["rounds"]])
+            total_s += sum([r["metrics"]["SUBMITTED"] for r in f["rounds"]])
+        assert total_ns == exp_not_started
+        assert total_ip == exp_in_progress
+        assert total_c == exp_completed
+        assert total_s == exp_submitted
 
 
 @pytest.mark.fund_round_config(

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -51,6 +51,36 @@ def test_get_application_statuses_csv(client, seed_application_records, _db):
     )
 
 
+@pytest.mark.apps_to_insert(test_application_data)
+def test_get_application_statuses_json(client, seed_application_records, _db):
+    response = client.get(
+        "/applications/reporting/applications_statuses_data?format=json",
+        follow_redirects=True,
+    )
+    result = response.json
+    assert result
+    assert result["NOT_STARTED"] == 3
+    assert result["IN_PROGRESS"] == 0
+    assert result["SUBMITTED"] == 0
+    assert result["COMPLETED"] == 0
+
+    app = get_row_by_pk(Applications, seed_application_records[0].id)
+    app.status = "IN_PROGRESS"
+    _db.session.add(app)
+    _db.session.commit()
+
+    response = client.get(
+        "/applications/reporting/applications_statuses_data?format=json",
+        follow_redirects=True,
+    )
+    result = response.json
+    assert result
+    assert result["NOT_STARTED"] == 2
+    assert result["IN_PROGRESS"] == 1
+    assert result["SUBMITTED"] == 0
+    assert result["COMPLETED"] == 0
+
+
 user_lang = {
     "account_id": "usera",
     "language": "en",


### PR DESCRIPTION
### Change description
Updated existing `get_applications_statuses_report` function to accept an optional `format` param to allow returning the data in json so we can consume it from assessment (defaults to csv).

Updated the format to breakdown numbers by fund and round so we can populate the assessment dashboard with just one call to application store (rather than one per round).


- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed) (confluence: https://dluhcdigital.atlassian.net/wiki/spaces/FS/pages/5238959/Application+report+scripts)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Pull this branch and run locally. Then visit the following URLs:
- http://localhost:3002/applications/reporting/applications_statuses_data?format=json Should give you JSON data in the response
- http://localhost:3002/applications/reporting/applications_statuses_data should respond with a csv file as an attachment, as now.
The data in both responses should be the same, just different formats.

