### PR TITLE
FS-3441 added yelp hook for secrets

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -2,6 +2,8 @@ FLASK_APP=app.py
 FLASK_ENV=development
 FLASK_RUN_PORT=5000
 FLASK_RUN_HOST=localhost
+
+# Below credentials belongs to local development server. Do not commit any external services credentials
 DATABASE_URL=postgresql://postgres:password@localhost:5432/application_store
 FUND_STORE_API_HOST=http://localhost:3001
 AWS_ACCESS_KEY_ID=FSDIOSFODNN7EXAMPLE

--- a/.github/workflows/manual-dev-deploy.yaml
+++ b/.github/workflows/manual-dev-deploy.yaml
@@ -48,10 +48,10 @@
         perf_test_target_url_application_store: https://funding-service-design-application-store-dev.london.cloudapps.digital
         perf_test_target_url_fund_store: https://funding-service-design-fund-store-dev.london.cloudapps.digital
         perf_test_target_url_assessment_store: https://funding-service-design-assessment-store-dev.london.cloudapps.digital
-        e2e_tests_target_url_frontend: https://fsd:fsd@frontend.dev.gids.dev
-        e2e_tests_target_url_authenticator: https://fsd:fsd@authenticator2.dev.gids.dev
-        e2e_tests_target_url_form_runner: https://fsd:fsd@forms.dev.gids.dev
-        e2e_tests_target_url_assessment: https://fsd:fsd@assessment.dev.gids.dev
+        e2e_tests_target_url_frontend: https://fsd:fsd@frontend.dev.gids.dev  # pragma: allowlist secret
+        e2e_tests_target_url_authenticator: https://fsd:fsd@authenticator2.dev.gids.dev  # pragma: allowlist secret
+        e2e_tests_target_url_form_runner: https://fsd:fsd@forms.dev.gids.dev  # pragma: allowlist secret
+        e2e_tests_target_url_assessment: https://fsd:fsd@assessment.dev.gids.dev  # pragma: allowlist secret
         run_performance_tests: true
         run_e2e_tests: false
       secrets:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,3 +29,9 @@ repos:
     hooks:
     -   id: pyupgrade
         args: ["--py39-plus"]
+- repo: https://github.com/Yelp/detect-secrets
+  rev: v1.4.0
+  hooks:
+  -   id: detect-secrets
+      args: ['--disable-plugin', 'HexHighEntropyString']
+      exclude: .env.development

--- a/README.md
+++ b/README.md
@@ -58,7 +58,10 @@ Set the environment variables "DATABASE_URL" to your postgres connection string 
 
 Eg.
 
-`export DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/postgres`
+```
+# pragma: allowlist nextline secret
+export DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/postgres
+```
 
 
 ### Build with Paketo
@@ -204,7 +207,7 @@ To seed applicaitons, we need the completed form json. If you have that, skip to
 1. Get a submitted application into your local DB. You can either do this manually or by running the automated tests against your local docker runner.
 1. Find the `application_id` of that submitted application._
 1. Edit the [tests file](/tests/test_seed_db.py) to un-skip `test_retrieve_test_data` and then set `target_app` to be the `application_id` you just submitted.
-1. Update your unit test config to point at the same DB as the docker runner. Update [pytest.ini](/pytest.ini) so that `D:DATABASE_URL` points at the docker runner application store db: `D:DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5433/application_store`
+1. Update your unit test config to point at the same DB as the docker runner. Update [pytest.ini](/pytest.ini) so that `D:DATABASE_URL` points at the docker runner application store db: `D:DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5433/application_store  # pragma: allowlist secret`
 1. Run the single test `test_retrieve_test_data` - this should output the json of all the completed forms for that application into funding-service-design-store/forms.json.
 1. Copy this file into [seed_data](/tests/seed_data/) and name it `<fund_short_code>_<round_short_code>_all_forms.json`.
 1. *IMPORTANT* Change the config in [pytest.ini](/pytest.ini) back to what it was so you don't accidentally wipe your docker runner DB next time you run tests!

--- a/config/envs/unit_testing.py
+++ b/config/envs/unit_testing.py
@@ -10,7 +10,7 @@ from fsd_utils.config.commonconfig import CommonConfig
 @configclass
 class UnitTestingConfig(DefaultConfig):
     #  Application Config
-    SECRET_KEY = "dev"
+    SECRET_KEY = "dev"  # pragma: allowlist secret
     SESSION_COOKIE_NAME = CommonConfig.SESSION_COOKIE_NAME
     FLASK_ENV = "unit_test"
     FUND_STORE_API_HOST = DefaultConfig.TEST_FUND_STORE_API_HOST
@@ -21,7 +21,7 @@ class UnitTestingConfig(DefaultConfig):
     # Database
     SQLALCHEMY_DATABASE_URI = environ.get(
         "DATABASE_URL",
-        "postgresql://postgres:postgres@localhost:5432/fsd_app_store_test",
+        "postgresql://postgres:postgres@localhost:5432/fsd_app_store_test",  # pragma: allowlist secret
     )
     SQLALCHEMY_TRACK_MODIFICATIONS = False
 

--- a/copilot/environments/addons/funding-service-magic-links.yml
+++ b/copilot/environments/addons/funding-service-magic-links.yml
@@ -90,7 +90,7 @@ Outputs:
     Value:
       !Sub
       - "rediss://:${PASSWORD}@${HOSTNAME}:${PORT}"
-      - PASSWORD: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref 'RedisSecret', ":SecretString:password}}" ]]
+      - PASSWORD: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref 'RedisSecret', ":SecretString:password}}" ]]  # pragma: allowlist secret
         HOSTNAME: !GetAtt 'Redis.RedisEndpoint.Address'
         PORT: !GetAtt 'Redis.RedisEndpoint.Port'
     Export:

--- a/copilot/fsd-application-store/addons/fsd-application-store-cluster.yml
+++ b/copilot/fsd-application-store/addons/fsd-application-store-cluster.yml
@@ -85,9 +85,9 @@ Resources:
     Type: 'AWS::RDS::DBCluster'
     Properties:
       MasterUsername:
-        !Join [ "",  [ '{{resolve:secretsmanager:', !Ref fsdapplicationstoreclusterAuroraSecret, ":SecretString:username}}" ]]
+        !Join [ "",  [ '{{resolve:secretsmanager:', !Ref fsdapplicationstoreclusterAuroraSecret, ":SecretString:username}}" ]]  # pragma: allowlist secret
       MasterUserPassword:
-        !Join [ "",  [ '{{resolve:secretsmanager:', !Ref fsdapplicationstoreclusterAuroraSecret, ":SecretString:password}}" ]]
+        !Join [ "",  [ '{{resolve:secretsmanager:', !Ref fsdapplicationstoreclusterAuroraSecret, ":SecretString:password}}" ]]  # pragma: allowlist secret
       DatabaseName: !Ref fsdapplicationstoreclusterDBName
       Engine: 'aurora-postgresql'
       EngineVersion: '14.4'
@@ -126,11 +126,11 @@ Outputs:
     Value:
       !Sub
       - "postgres://${USERNAME}:${PASSWORD}@${HOSTNAME}:${PORT}/${DBNAME}"
-      - USERNAME: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref fsdapplicationstoreclusterAuroraSecret, ":SecretString:username}}" ]]
-        PASSWORD: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref fsdapplicationstoreclusterAuroraSecret, ":SecretString:password}}" ]]
-        HOSTNAME: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref fsdapplicationstoreclusterAuroraSecret, ":SecretString:host}}" ]]
-        PORT: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref fsdapplicationstoreclusterAuroraSecret, ":SecretString:port}}" ]]
-        DBNAME: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref fsdapplicationstoreclusterAuroraSecret, ":SecretString:dbname}}" ]]
+      - USERNAME: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref fsdapplicationstoreclusterAuroraSecret, ":SecretString:username}}" ]]  # pragma: allowlist secret
+        PASSWORD: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref fsdapplicationstoreclusterAuroraSecret, ":SecretString:password}}" ]]  # pragma: allowlist secret
+        HOSTNAME: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref fsdapplicationstoreclusterAuroraSecret, ":SecretString:host}}" ]]  # pragma: allowlist secret
+        PORT: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref fsdapplicationstoreclusterAuroraSecret, ":SecretString:port}}" ]]  # pragma: allowlist secret
+        DBNAME: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref fsdapplicationstoreclusterAuroraSecret, ":SecretString:dbname}}" ]]  # pragma: allowlist secret
 
   fsdapplicationstoreclusterSecret: # injected as FSDAPPLICATIONSTORECLUSTER_SECRET environment variable by Copilot.
     Description: "The JSON secret that holds the database username and password. Fields are 'host', 'port', 'dbname', 'username', 'password', 'dbClusterIdentifier' and 'engine'"

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,6 +2,7 @@
 env =
     FLASK_ENV=unit_test
     FLASK_DEBUG=1
+    # pragma: allowlist nextline secret
     D:DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/fsd_app_store_test
     GITHUB_SHA=abc123
 mocked-sessions=db.db.session

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,7 +1,6 @@
 # How to run tests
 
-1. Ensure that the environment variable DATABASE_URL is set to your db's connection string. The default during tests is:
-   `postgresql://postgres:postgres@127.0.0.1:5432/fsd_app_store_test`, unless you manually set DATABASE_URL.
+1. Ensure that the environment variable DATABASE_URL is set to your db's connection string.
    - The command `invoke bootstrap-test-db --database-host=your-db-url` will create a db called "fsd_app_store_test".
 2. Ensure you have installed the requirements-dev.txt
 3. Run `pytest`


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FS-3441

### Description
- Added pre-commit 'Yelp/detect-secrets' to prevent committing of secrets to code base
- Ignore false positives by marking them with `pragma: allowlist secret`
- disabled the plugin `HexHighEntropyString` which tend to detect lot of false positives

### How to test
- Add a secret/API key/password to any of the file type
  For eg. `API_KEY= "125fdfbdjhbj5989"`
- stage the file & commit it.
- Notice the commit is failed with errors. 