### PR TITLE
FS-3669 add report mappings for CYP

### DIFF
--- a/config/key_report_mappings/dpif_r2_key_report_mapping.py
+++ b/config/key_report_mappings/dpif_r2_key_report_mapping.py
@@ -1,0 +1,18 @@
+from config.key_report_mappings.model import FormMappingItem
+from config.key_report_mappings.model import KeyReportMapping
+
+DPIF_R2_KEY_REPORT_MAPPING = KeyReportMapping(
+    round_id="0059aad4-5eb5-11ee-8c99-0242ac120002",
+    mapping=[
+        FormMappingItem(
+            form_name="organisation-information-dpi",
+            key="IRugBv",
+            return_field="applicant_email",
+        ),
+        FormMappingItem(
+            form_name="organisation-information-dpi",
+            key="nYJiWy",
+            return_field="organisation_name",
+        ),
+    ],
+)

--- a/config/key_report_mappings/mappings.py
+++ b/config/key_report_mappings/mappings.py
@@ -9,11 +9,15 @@ from config.key_report_mappings.cof_r3w2_key_report_mapping import (
 from config.key_report_mappings.cyp_r1_key_report_mapping import (
     CYP_R1_KEY_REPORT_MAPPING,
 )
+from config.key_report_mappings.dpif_r2_key_report_mapping import (
+    DPIF_R2_KEY_REPORT_MAPPING,
+)
 
 MAPPINGS = (
     COF_R2_KEY_REPORT_MAPPING,
     COF_R3W2_KEY_REPORT_MAPPING,
     CYP_R1_KEY_REPORT_MAPPING,
+    DPIF_R2_KEY_REPORT_MAPPING,
 )
 
 ROUND_ID_TO_KEY_REPORT_MAPPING = defaultdict(
@@ -30,3 +34,5 @@ def get_report_mapping_for_round(round_id):
         return COF_R3W2_KEY_REPORT_MAPPING
     elif round_id == CYP_R1_KEY_REPORT_MAPPING.round_id:
         return CYP_R1_KEY_REPORT_MAPPING
+    elif round_id == DPIF_R2_KEY_REPORT_MAPPING.round_id:
+        return DPIF_R2_KEY_REPORT_MAPPING

--- a/db/queries/feedback/queries.py
+++ b/db/queries/feedback/queries.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 
-import jsonpath_rw_ext
 from config.key_report_mappings.mappings import get_report_mapping_for_round
 from db import db
 from db.models import Applications
@@ -11,6 +10,7 @@ from db.queries.reporting.queries import map_application_key_fields
 from db.schemas.application import ApplicationSchema
 from db.schemas.end_of_application_survey import EndOfApplicationSurveyFeedbackSchema
 from external_services.data import get_application_sections
+from flask import current_app
 
 
 def upsert_feedback(
@@ -95,15 +95,6 @@ def retrieve_end_of_application_survey_data(application_id, page_number):
 
 
 def retrieve_all_feedbacks_and_surveys(fund_id, round_id, status):
-    def get_answer_value(form, search_key, search_value):
-        return (
-            jsonpath_rw_ext.parse(
-                f"$.questions[*].fields[?(@.{search_key} == '{search_value}')]"
-            )
-            .find(form)[0]
-            .value["answer"]
-        )
-
     filters = []
     section_names = {}
     sections_feedback = []
@@ -139,7 +130,9 @@ def retrieve_all_feedbacks_and_surveys(fund_id, round_id, status):
             applicant_email = result["applicant_email"]
             applicant_organisation = result["organisation_name"]
         except Exception as e:
-            print(f"Coudn't extract applicant email & organisation.  Exception :{e}")
+            current_app.logger.error(
+                f"Coudn't extract applicant email & organisation.  Exception :{e}"
+            )
             applicant_email = ""
             applicant_organisation = ""
 

--- a/db/queries/feedback/queries.py
+++ b/db/queries/feedback/queries.py
@@ -125,7 +125,9 @@ def retrieve_all_feedbacks_and_surveys(fund_id, round_id, status):
         # extract applicant email & organisation
         try:
             result = map_application_key_fields(
-                applicant_serialiser.dump(application), mapping_report.mapping, round_id
+                applicant_serialiser.dump(application),
+                mapping_report.mapping,
+                mapping_report.round_id,
             )
             applicant_email = result["applicant_email"]
             applicant_organisation = result["organisation_name"]

--- a/tests/test_all_feedbacks.py
+++ b/tests/test_all_feedbacks.py
@@ -1,4 +1,7 @@
 import pytest
+from config.key_report_mappings.cof_r3w2_key_report_mapping import (
+    COF_R3W2_KEY_REPORT_MAPPING,
+)
 from db.models import Applications
 from db.models import EndOfApplicationSurveyFeedback
 from db.models import Feedback
@@ -13,7 +16,30 @@ app_sections = [
 applications = [
     Applications(
         id="app_1",
-        forms=[Forms()],
+        forms=[
+            Forms(
+                name="applicant-information-cof-r3-w2",
+                json=[
+                    {
+                        "questions": "Lead contact details",
+                        "fields": [{"key": "NlHSBg", "answer": "test@test.com"}],
+                    }
+                ],
+            ),
+            Forms(
+                name="organisation-information-cof-r3-w2",
+                json=[
+                    {
+                        "questions": "organisation information",
+                        "fields": [
+                            {"key": "WWWWxy", "answer": "Ref1234"},
+                            {"key": "YdtlQZ", "answer": "OrgName"},
+                            {"key": "lajFtB", "answer": "Non-Profit"},
+                        ],
+                    }
+                ],
+            ),
+        ],
         feedbacks=[
             Feedback(
                 section_id="62",
@@ -48,20 +74,13 @@ applications = [
 
 
 @pytest.mark.parametrize(
-    "app_sections,applications",
+    "app_sections,applications,report_mapping",
     [
-        (
-            [
-                app_sections,
-                applications,
-            ]
-        ),
+        ([app_sections, applications, COF_R3W2_KEY_REPORT_MAPPING]),
     ],
 )
 def test_retrieve_all_feedbacks_and_surveys(
-    mocker,
-    app_sections,
-    applications,
+    mocker, app_sections, applications, report_mapping
 ):
     mocker.patch(
         "db.queries.feedback.queries.get_application_sections",
@@ -70,6 +89,10 @@ def test_retrieve_all_feedbacks_and_surveys(
     mocker.patch(
         "db.queries.feedback.queries.get_applications",
         return_value=applications,
+    )
+    mocker.patch(
+        "db.queries.feedback.queries.get_report_mapping_for_round",
+        return_value=report_mapping,
     )
 
     result = retrieve_all_feedbacks_and_surveys("test_fund", "test_round", "SUBMITTED")


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FS-3669

### Description
Added DPIF fund report mappings, which is required for extracting applicants email & organisation for export feedback report link on assessment

### How to test
- Checkout the branch
- Rebuild the container
- Go to swagger & test the API
![image](https://github.com/communitiesuk/funding-service-design-application-store/assets/127315890/fa814574-2b2d-4729-a359-94aa3f5366ca)