### PR TITLE
FS-3604: Add healthcheck for queues

### DIFF
--- a/openapi/api.yml
+++ b/openapi/api.yml
@@ -548,3 +548,46 @@ paths:
                 code: 500
                 status: 'error'
                 message: 'Message could not be staged'
+
+  /queue_healthcheck:
+    get:
+      tags:
+        - SQS (queues)
+      summary: Check the health status of one or all queues
+      description: Returns the health status of the specified queue, or all queues if no specific queue is requested.
+      operationId: api.QueueView.health_check
+      parameters:
+        - name: queue_prefix
+          in: query
+          required: false
+          schema:
+            type: string
+          description: The prefix of the queue(s) to check. If omitted, all queues will be checked.
+      responses:
+        200:
+          description: SUCCESS - Health status of the queue(s).
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: boolean
+              examples:
+                single_queue_health:
+                  value:
+                    "queue_name_1": true
+                all_queues_health:
+                  value:
+                    "queue_name_1": true
+                    "queue_name_2": false
+                    "queue_name_3": true
+        500:
+          description: ERROR - Could not check the health status of the queue(s).
+          content:
+            application/json:
+              schema:
+                $ref: 'components.yml#/components/schemas/Error'
+              example:
+                code: 500
+                status: 'error'
+                message: 'Failed to retrieve queue health status'


### PR DESCRIPTION
### Change description

- Add endpoint for health-checking queues
- Can specify a pre-fix or just leave blank
- Will return a dictionary of queue name to boolean, depending on result/health

I'm a little against adding this change, since it will be redundant in a few weeks once we have cloudwatch to monitor the health of the queues - and also because it piggybacks/pollutes the existing queues (submitting and receiving just to verify it works), not sure if we should be polluting the queues like that.

---

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines