### PR TITLE
FS-3855: Remove date-time from openapi schema

### DIFF
--- a/openapi/components.yml
+++ b/openapi/components.yml
@@ -180,7 +180,6 @@ components:
           type: string
         date_submitted:
           type: string
-          format: date-time
     PostFeedback:
       type: object
       properties:
@@ -238,4 +237,3 @@ components:
           additionalProperties: true
         date_submitted:
           type: string
-          format: date-time


### PR DESCRIPTION
### Change description

[Stack Trace](https://funding-service-design-team-dl.sentry.io/share/issue/0fd5ccbb471c46c99f8dd4780686a054/#exception)
```
Newest

NonConformingResponseBody
'2023-12-05T12:17:07.188422' is not a 'date-time'

Failed validating 'format' in schema['properties']['date_submitted']:
    {'format': 'date-time', 'type': 'string'}

On instance['date_submitted']:
    '2023-12-05T12:17:07.188422'
```

--- 

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines
