### PR TITLE
fs-3691 forcing english on application creation if welsh is not avail…

### DIFF
--- a/api/routes/application/routes.py
+++ b/api/routes/application/routes.py
@@ -59,7 +59,12 @@ class ApplicationsView(MethodView):
         round_id = args["round_id"]
         fund_id = args["fund_id"]
         language = args["language"]
-        empty_forms = get_blank_forms(fund_id, round_id, language)
+        fund = get_fund(fund_id=fund_id)
+        if language == "cy" and not fund.welsh_available:
+            language = "en"
+        empty_forms = get_blank_forms(
+            fund_id=fund_id, round_id=round_id, language=language
+        )
         application = create_application(
             account_id=account_id,
             fund_id=fund_id,

--- a/db/models/application/applications.py
+++ b/db/models/application/applications.py
@@ -58,8 +58,10 @@ class Applications(BaseModel):
             "language": self.language.name if self.language else "en",
             "reference": self.reference,
             "project_name": self.project_name or None,
-            "started_at": self.started_at.isoformat(),
-            "status": self.status.name,
-            "last_edited": (self.last_edited or self.started_at).isoformat(),
+            "started_at": self.started_at.isoformat() if self.started_at else None,
+            "status": self.status.name if self.status else None,
+            "last_edited": self.last_edited.isoformat()
+            if self.last_edited
+            else (self.started_at.isoformat() if self.started_at else None),
             "date_submitted": date_submitted,
         }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -250,6 +250,7 @@ def mock_get_fund(mocker):
     Used with unique_fund_round to ensure when the fund and
     round are retrieved, they match what's expected
     """
+    mocker.patch("api.routes.application.routes.get_fund", new=generate_mock_fund)
     mocker.patch("db.queries.application.queries.get_fund", new=generate_mock_fund)
 
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,8 +2,10 @@ import json
 import os
 import re
 import urllib
+from datetime import datetime
 
 from config import Config
+from db.models.application.enums import Language
 from deepdiff import DeepDiff
 
 
@@ -159,7 +161,7 @@ test_application_data = [
         "account_id": "usera",
         "fund_id": "47aef2f5-3fcb-4d45-acb5-f0152b5f03c4",
         "round_id": "c603d114-5364-4474-a0c4-c41cbf4d3bbd",
-        "language": "en",
+        "language": Language.en,
     },
     {
         "account_id": "userb",
@@ -171,7 +173,7 @@ test_application_data = [
         "account_id": "userc",
         "fund_id": "funding-service-design",
         "round_id": "spring",
-        "language": "cy",
+        "language": Language.cy,
     },
 ]
 
@@ -297,11 +299,11 @@ test_question_data_cy = [
 
 application_expected_data = [
     {
-        "status": "NOT_STARTED",
         "project_name": "project_name not set",
-        "date_submitted": "null",
-        "started_at": "2022-05-20 14:47:12",
+        "date_submitted": None,
+        "started_at": datetime.fromisoformat("2022-05-20 14:47:12"),
         "last_edited": None,
+        "status": None,
         **application_data,
     }
     for application_data in test_application_data


### PR DESCRIPTION
### Change description
If the language cookie was set to welsh but you tried to create an application in a fund that doesn't support welsh, the application was created in english but when requesting the blank forms to setup the application, they were requested in welsh. This resulted in no forms being populated for that application.
Have updated the create application methods and tests to force english if welsh is not available for all aspects of create application

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
- Set language to welsh
- From 'all your applications' navigate to a fund that does not support welsh
- Create a new application
- Application should be created and displayed to the user correctly (no errors)
