### PR TITLE
refactor-endpoint/FS-3845-send-application-reminder-script

### DIFF
--- a/openapi/api.yml
+++ b/openapi/api.yml
@@ -57,7 +57,9 @@ paths:
           name: status_only
           style: form
           schema:
-            type: string
+            type: array
+            items:
+              type: string
           required: false
           explode: false
         # - filtering applications

--- a/openapi/api.yml
+++ b/openapi/api.yml
@@ -61,7 +61,7 @@ paths:
             items:
               type: string
           required: false
-          explode: false
+          explode: true
         # - filtering applications
         - in: query
           name: order_by


### PR DESCRIPTION
The endpoint  GET /applications now accepts array of status_only as well as string
