### PR TITLE
FS-4175-capitalize-full-name-for-lead-contact-when-sending-invite

### DIFF
--- a/api/routes/application/routes.py
+++ b/api/routes/application/routes.py
@@ -226,7 +226,7 @@ class ApplicationsView(MethodView):
                 Notification.send(
                     notify_template,
                     account.email,
-                    full_name.capitalize(),
+                    full_name.title(),
                     contents,
                 )
             return {

--- a/api/routes/application/routes.py
+++ b/api/routes/application/routes.py
@@ -226,7 +226,7 @@ class ApplicationsView(MethodView):
                 Notification.send(
                     notify_template,
                     account.email,
-                    full_name,
+                    full_name.capitalize(),
                     contents,
                 )
             return {


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/jira/software/c/projects/FS/boards/50?selectedIssue=FS-4175

The lead contact name is Capitalised when posting contents to the notification service for COF-EOI  fund round 
