### PR TITLE
FS-4411:Over-provision instance and change to Fargate-spot 

### DIFF
--- a/copilot/fsd-application-store/manifest.yml
+++ b/copilot/fsd-application-store/manifest.yml
@@ -31,13 +31,13 @@ memory: 1024
 platform: linux/x86_64
 
 # Number of tasks that should be running in your service.
-count: 2
+count: 1
 
 # Enable running commands in your container.
 exec: true
 
 network:
-  connect: true # Enable Service Connect for intra-environment traffic between services.
+  connect: false # Enable Service Connect for intra-environment traffic between services.
 
 # Optional fields for more advanced use-cases.
 #
@@ -58,9 +58,14 @@ variables:
 
 # You can override any of the values defined above by environment.
 environments:
+  dev:
+    count:
+      spot: 1
   test:
     deployment:
       rolling: 'recreate'
+    count:
+      spot: 2
   uat:
     count:
       range: 2-4

--- a/copilot/fsd-application-store/manifest.yml
+++ b/copilot/fsd-application-store/manifest.yml
@@ -37,7 +37,7 @@ count: 1
 exec: true
 
 network:
-  connect: false # Enable Service Connect for intra-environment traffic between services.
+  connect: true # Enable Service Connect for intra-environment traffic between services.
 
 # Optional fields for more advanced use-cases.
 #


### PR DESCRIPTION
-FS-4411: Overprovision instance

Change description
Reduce the number of instance to 1 in Dev and change the ECS launch_type to Fargate-spot.

Unit tests and other appropriate tests added or updated
README and other documentation has been updated / added (if needed)
Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")
How to test
_Will check after deployment by logging into the ECS console and view the service and instance configuration




### Screenshots of UI changes (if applicable)
