### PR TITLE
FS-4287: adding q and a file creation to application store based on a param and if the param is sent then only file will be send as a base64 encoded.

### DIFF
--- a/api/routes/application/routes.py
+++ b/api/routes/application/routes.py
@@ -79,7 +79,7 @@ class ApplicationsView(MethodView):
         add_new_forms(forms=empty_forms, application_id=application.id)
         return application.as_dict(), 201
 
-    def get_by_id(self, application_id, with_questions_file=None):
+    def get_by_id(self, application_id, with_questions_file=False):
         try:
             return_dict = get_application(application_id, as_json=True, include_forms=True)
             return_dict = create_qa_base64file(return_dict, with_questions_file)

--- a/api/routes/application/routes.py
+++ b/api/routes/application/routes.py
@@ -82,7 +82,8 @@ class ApplicationsView(MethodView):
     def get_by_id(self, application_id, **kwargs):
         try:
             return_dict = get_application(application_id, as_json=True, include_forms=True)
-            return_dict = create_qa_base64file(return_dict, **kwargs)
+            with_questions_file = kwargs.get("with_questions_file", None)
+            return_dict = create_qa_base64file(return_dict, with_questions_file)
             return return_dict, 200
         except ValueError as e:
             current_app.logger.error("Value error getting application ID: {application_id}")

--- a/api/routes/application/routes.py
+++ b/api/routes/application/routes.py
@@ -79,10 +79,9 @@ class ApplicationsView(MethodView):
         add_new_forms(forms=empty_forms, application_id=application.id)
         return application.as_dict(), 201
 
-    def get_by_id(self, application_id, **kwargs):
+    def get_by_id(self, application_id, with_questions_file=None):
         try:
             return_dict = get_application(application_id, as_json=True, include_forms=True)
-            with_questions_file = kwargs.get("with_questions_file", None)
             return_dict = create_qa_base64file(return_dict, with_questions_file)
             return return_dict, 200
         except ValueError as e:

--- a/api/routes/application/routes.py
+++ b/api/routes/application/routes.py
@@ -22,6 +22,7 @@ from db.queries import search_applications
 from db.queries import submit_application
 from db.queries import update_form
 from db.queries import upsert_feedback
+from db.queries.application import create_qa_base64file
 from db.queries.feedback import retrieve_all_feedbacks_and_surveys
 from db.queries.feedback import retrieve_end_of_application_survey_data
 from db.queries.feedback import upsert_end_of_application_survey_data
@@ -78,9 +79,10 @@ class ApplicationsView(MethodView):
         add_new_forms(forms=empty_forms, application_id=application.id)
         return application.as_dict(), 201
 
-    def get_by_id(self, application_id):
+    def get_by_id(self, application_id, **kwargs):
         try:
             return_dict = get_application(application_id, as_json=True, include_forms=True)
+            return_dict = create_qa_base64file(return_dict, **kwargs)
             return return_dict, 200
         except ValueError as e:
             current_app.logger.error("Value error getting application ID: {application_id}")

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -68,6 +68,7 @@ class DefaultConfig:
     SQLALCHEMY_DATABASE_URI = environ.get("DATABASE_URL")
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     SQLALCHEMY_ENGINE_OPTIONS = {"future": True}
+    DOCUMENT_UPLOAD_SIZE_LIMIT = 2 * 1024 * 1024
 
     # ---------------
     # AWS Overall Config

--- a/db/queries/application/queries.py
+++ b/db/queries/application/queries.py
@@ -183,8 +183,13 @@ def get_count_by_status(round_ids: Optional[list] = [], fund_ids: Optional[list]
     return results
 
 
-def create_qa_base64file(application_data: dict, with_questions_file):
-    if with_questions_file is not None and with_questions_file:
+def create_qa_base64file(application_data: dict, with_questions_file: bool):
+    """
+    If the query param with_questions_file is True then it will get the application questions ans answers,
+    and then it will generate a formatted text document for an application with questions and answers.
+    and this file will be base64 encoded.
+    """
+    if with_questions_file:
         fund_details = get_fund(application_data["fund_id"])
         q_and_a = extract_questions_and_answers(application_data["forms"], application_data["language"])
         contents = BytesIO(

--- a/openapi/api.yml
+++ b/openapi/api.yml
@@ -153,6 +153,13 @@ paths:
           schema:
             type: string
             format: path
+        - in: query
+          name: with_questions_file
+          style: form
+          schema:
+            type: boolean
+          required: false
+          explode: false
 
   /applications/forms:
     put:


### PR DESCRIPTION
FS-4287: adding q and a file creation to application store based on a param and if the param is sent then only file will be send as a base64 encoded.

https://dluhcdigital.atlassian.net/browse/FS-4287 

### Change description
adding q and a file creation to application store based on a param and if the param is sent then only file will be send as a base64 encoded.

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
based on the with_questions_file=true query param it will send the file details other wise it will work as is
