### PR TITLE
FS-4287: When application is submitted and need to send an email we no longer send whole form instead generate base64encoded file with formatted file that compatible for gov notify

### DIFF
--- a/api/routes/application/routes.py
+++ b/api/routes/application/routes.py
@@ -216,6 +216,8 @@ class ApplicationsView(MethodView):
                 }
 
             if should_send_email:
+                contents["application"] = create_qa_base64file(contents.get("application"), True)
+                del contents["application"]["forms"]
                 message_id = Notification.send(
                     notify_template,
                     account.email,

--- a/tests/seed_data/application_data.py
+++ b/tests/seed_data/application_data.py
@@ -1,0 +1,54 @@
+from fsd_utils import NotifyConstants
+
+expected_application_json = {
+    NotifyConstants.FIELD_TYPE: NotifyConstants.TEMPLATE_TYPE_APPLICATION,
+    NotifyConstants.FIELD_TO: "test_application@example.com",
+    NotifyConstants.FIELD_CONTENT: {
+        NotifyConstants.MAGIC_LINK_CONTACT_HELP_EMAIL_FIELD: "COF@levellingup.gov.uk",
+        NotifyConstants.APPLICATION_FIELD: {
+            "id": "123456789",
+            "reference": "1564564564-56-4-54-4654",
+            "fund_id": "47aef2f5-3fcb-4d45-acb5-f0152b5f03c4",
+            "round_name": "summer",
+            "date_submitted": "2022-05-14T09:25:44.124542",
+            "fund_name": "Community Ownership Fund",
+            "language": "en",
+            NotifyConstants.APPLICATION_FORMS_FIELD: [
+                {
+                    NotifyConstants.APPLICATION_NAME_FIELD: "about-your-org",
+                    NotifyConstants.APPLICATION_QUESTIONS_FIELD: [
+                        {
+                            "question": "Application information",
+                            "fields": [
+                                {
+                                    "key": "application-name",
+                                    "title": "Applicant name",
+                                    "type": "text",
+                                    "answer": "Jack-Simon",
+                                },
+                                {
+                                    "key": "upload-file",
+                                    "title": "Upload file",
+                                    "type": "file",
+                                    "answer": "012ba4c7-e4971/test-one_two.three/programmer.jpeg",  # noqa
+                                },
+                                {
+                                    "key": "boolean-question-1",
+                                    "title": "Boolean Question 1 ",
+                                    "type": "list",
+                                    "answer": False,
+                                },
+                                {
+                                    "key": "boolean-question-2",
+                                    "title": "Boolean Question 2",
+                                    "type": "list",
+                                    "answer": True,
+                                },
+                            ],
+                        }
+                    ],
+                }
+            ],
+        },
+    },
+}


### PR DESCRIPTION
FS-4287: When application is submitted and need to send an email we no longer send whole form instead generate base64encoded file with formatted file that compatible for gov notify

https://dluhcdigital.atlassian.net/browse/FS-4287


### Change description
When application is submitted and need to send an email we no longer send whole form instead generate base64encoded file with formatted file that compatible for gov notify

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Once application is submitted content of the application should be send through email
