### PR TITLE
Update support email to communities from levellingup

### DIFF
--- a/tests/seed_data/application_data.py
+++ b/tests/seed_data/application_data.py
@@ -4,7 +4,7 @@ expected_application_json = {
     NotifyConstants.FIELD_TYPE: NotifyConstants.TEMPLATE_TYPE_APPLICATION,
     NotifyConstants.FIELD_TO: "test_application@example.com",
     NotifyConstants.FIELD_CONTENT: {
-        NotifyConstants.MAGIC_LINK_CONTACT_HELP_EMAIL_FIELD: "COF@levellingup.gov.uk",
+        NotifyConstants.MAGIC_LINK_CONTACT_HELP_EMAIL_FIELD: "COF@communities.gov.uk",
         NotifyConstants.APPLICATION_FIELD: {
             "id": "123456789",
             "reference": "1564564564-56-4-54-4654",


### PR DESCRIPTION
### Change description
The old COF support email was using the levellingup domain ( [cof@levellingup.gov.uk](mailto:cof@levellingup.gov.uk) ). This has been updated to the communities domain ( [cof@communities.gov.uk](mailto:cof@communities.gov.uk) )

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
