### PR TITLE
Upgrade pre-commit

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -3,7 +3,7 @@ black
 click
 debugpy
 deepdiff
-pre-commit
+pre-commit~=4.0.0
 pytest
 pytest-env
 pytest-flask

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -331,7 +331,7 @@ ply==3.11
     #   jsonpath-rw
 prance==23.6.21.0
     # via -r requirements.txt
-pre-commit==3.7.1
+pre-commit==4.0.1
     # via -r requirements-dev.in
 psycopg2-binary==2.9.9
     # via -r requirements.txt


### PR DESCRIPTION
### Change description
Bumps our local pre-commit version to be >=4.0. This matches what runs in pre-commit.ci, so is best to keep roughly in sync.

In particular this bump has been prompted by CI failures on the assessment-store, where one of the installed hooks is incompatible with v4 of pre-commit because the `python_venv` "language" has been removed. We don't see this issue locally on that repo because we're still running an older version of pre-commmit.