### PR TITLE
Switching to ruff formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,36 +1,22 @@
 repos:
--   repo: https://github.com/psf/black
-    rev: 23.12.1
-    hooks:
-    - id: black
-      language_version: python3
-      args:
-        - --experimental-string-processing
--   repo: https://github.com/PyCQA/flake8
-    rev: 7.1.1
-    hooks:
-    - id: flake8
-      additional_dependencies: [Flake8-pyproject]
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-ast
--   repo: https://github.com/asottile/reorder-python-imports
-    rev: v3.14.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version. If bumping this, please also bump requirements-dev.in
+    rev: v0.6.7
     hooks:
-      - id: reorder-python-imports
-        name: Reorder Python imports (src, tests)
-        args: ["--application-directories", "src"]
--   repo: https://github.com/asottile/pyupgrade
-    rev: v3.19.0
+      # Run the linter.
+      - id: ruff
+        args: [--fix]
+      # Run the formatter.
+      - id: ruff-format
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.4.0
     hooks:
-    -   id: pyupgrade
-        args: ["--py39-plus"]
-- repo: https://github.com/Yelp/detect-secrets
-  rev: v1.5.0
-  hooks:
-  -   id: detect-secrets
-      args: ['--disable-plugin', 'HexHighEntropyString']
-      exclude: .env.development
+    -   id: detect-secrets
+        args: ['--disable-plugin', 'HexHighEntropyString']
+        exclude: .env.development

--- a/api/routes/application/routes.py
+++ b/api/routes/application/routes.py
@@ -3,51 +3,50 @@ import time
 from typing import Optional
 from uuid import uuid4
 
-from _helpers import get_blank_forms
-from _helpers import order_applications
+from flask import current_app, jsonify, request, send_file
+from flask.views import MethodView
+from fsd_utils import Decision, evaluate_response
+from fsd_utils.config.notify_constants import NotifyConstants
+from sqlalchemy.orm.exc import NoResultFound
+
+from _helpers import get_blank_forms, order_applications
 from config import Config
 from config.key_report_mappings.mappings import ROUND_ID_TO_KEY_REPORT_MAPPING
 from db.models.application.enums import Status
-from db.queries import add_new_forms
-from db.queries import create_application
-from db.queries import export_json_to_csv
-from db.queries import export_json_to_excel
-from db.queries import get_application
-from db.queries import get_feedback
-from db.queries import get_fund_id
-from db.queries import get_general_status_applications_report
-from db.queries import get_key_report_field_headers
-from db.queries import get_report_for_applications
-from db.queries import search_applications
-from db.queries import submit_application
-from db.queries import update_form
-from db.queries import upsert_feedback
+from db.queries import (
+    add_new_forms,
+    create_application,
+    export_json_to_csv,
+    export_json_to_excel,
+    get_application,
+    get_feedback,
+    get_fund_id,
+    get_general_status_applications_report,
+    get_key_report_field_headers,
+    get_report_for_applications,
+    search_applications,
+    submit_application,
+    update_form,
+    upsert_feedback,
+)
 from db.queries.application import create_qa_base64file
-from db.queries.feedback import retrieve_all_feedbacks_and_surveys
-from db.queries.feedback import retrieve_end_of_application_survey_data
-from db.queries.feedback import upsert_end_of_application_survey_data
-from db.queries.reporting.queries import export_application_statuses_to_csv
-from db.queries.reporting.queries import map_application_key_fields
-from db.queries.research import retrieve_research_survey_data
-from db.queries.research import upsert_research_survey_data
-from db.queries.statuses import check_is_fund_round_open
-from db.queries.statuses import update_statuses
-from external_services import get_account
-from external_services import get_fund
-from external_services import get_round
-from external_services import get_round_eoi_schema
-from external_services.exceptions import NotificationError
-from external_services.exceptions import SubmitError
+from db.queries.feedback import (
+    retrieve_all_feedbacks_and_surveys,
+    retrieve_end_of_application_survey_data,
+    upsert_end_of_application_survey_data,
+)
+from db.queries.reporting.queries import (
+    export_application_statuses_to_csv,
+    map_application_key_fields,
+)
+from db.queries.research import (
+    retrieve_research_survey_data,
+    upsert_research_survey_data,
+)
+from db.queries.statuses import check_is_fund_round_open, update_statuses
+from external_services import get_account, get_fund, get_round, get_round_eoi_schema
+from external_services.exceptions import NotificationError, SubmitError
 from external_services.models.notification import Notification
-from flask import current_app
-from flask import jsonify
-from flask import request
-from flask import send_file
-from flask.views import MethodView
-from fsd_utils import Decision
-from fsd_utils import evaluate_response
-from fsd_utils.config.notify_constants import NotifyConstants
-from sqlalchemy.orm.exc import NoResultFound
 
 
 class ApplicationsView(MethodView):
@@ -105,8 +104,8 @@ class ApplicationsView(MethodView):
 
     def get_applications_statuses_report(
         self,
-        round_id: Optional[list] = [],
-        fund_id: Optional[list] = [],
+        round_id: Optional[list] = None,
+        fund_id: Optional[list] = None,
         format: Optional[str] = "csv",
     ):
         try:
@@ -232,7 +231,10 @@ class ApplicationsView(MethodView):
                     full_name.title() if full_name else None,
                     contents,
                 )
-                current_app.logger.info(f"Message added to the queue msg_id: [{message_id}]")
+                current_app.logger.info(
+                    "Message added to the queue msg_id: [{message_id}]",
+                    extra=dict(message_id=message_id),
+                )
             return {
                 "id": application_id,
                 "reference": application_with_form_json["reference"],
@@ -241,19 +243,27 @@ class ApplicationsView(MethodView):
             }, 201
         except KeyError as e:
             current_app.logger.exception(
-                f"Key error on processing application submissionfor application: '{application_id}'"
+                "Key error on processing application submissionfor application: '{application_id}'",
+                extra=dict(application_id=application_id),
             )
             return str(e), 500, {"x-error": "key error"}
         except NotificationError as e:
             current_app.logger.exception(
-                f"Notification error on sending SUBMIT notification for application {application_id}"
+                "Notification error on sending SUBMIT notification for application {application_id}",
+                extra=dict(application_id=application_id),
             )
             return str(e), 500, {"x-error": "notification error"}
         except SubmitError as e:
-            current_app.logger.exception(f"Submit error on sending SUBMIT application {application_id}")
+            current_app.logger.exception(
+                "Submit error on sending SUBMIT application {application_id}",
+                extra=dict(application_id=application_id),
+            )
             return str(e), 500, {"x-error": "Submit error"}
         except Exception as e:
-            current_app.logger.exception(f"Error on sending SUBMIT notification for application {application_id}")
+            current_app.logger.exception(
+                "Error on sending SUBMIT notification for application {application_id}",
+                extra=dict(application_id=application_id),
+            )
             return str(e), 500, {"x-error": "Error"}
 
     def _send_submit_queue(self, application_id, application_with_form_json):
@@ -276,11 +286,14 @@ class ApplicationsView(MethodView):
                 message_deduplication_id=str(uuid4()),  # ensures message uniqueness
                 extra_attributes=application_attributes,
             )
-            current_app.logger.info(f"Message sent to SQS queue and message id is [{message_id}]")
+            current_app.logger.info(
+                "Message sent to SQS queue and message id is [{message_id}]",
+                extra=dict(message_id=message_id),
+            )
         except Exception as e:
             current_app.logger.error("An error occurred while sending message")
             current_app.logger.error(e)
-            raise SubmitError(message="Sorry, cannot submit the message")
+            raise SubmitError(message="Sorry, cannot submit the message") from e
 
     def post_feedback(self):
         args = request.get_json()

--- a/api/routes/queues/routes.py
+++ b/api/routes/queues/routes.py
@@ -2,10 +2,11 @@
 import json
 from uuid import uuid4
 
-from config import Config
-from db.queries import get_application
 from flask import current_app
 from flask.views import MethodView
+
+from config import Config
+from db.queries import get_application
 
 
 class QueueView(MethodView):
@@ -36,7 +37,10 @@ class QueueView(MethodView):
                     message_deduplication_id=str(uuid4()),  # ensures message uniqueness
                     extra_attributes=application_attributes,
                 )
-                current_app.logger.info(f"Message sent to SQS queue and message id is [{message_id}]")
+                current_app.logger.info(
+                    "Message sent to SQS queue and message id is [{message_id}]",
+                    extra=dict(message_id=message_id),
+                )
                 return f"Message queued, message_id is: {message_id}.", 201
             except Exception as e:
                 current_app.logger.error("An error occurred while sending message")

--- a/app.py
+++ b/app.py
@@ -1,18 +1,18 @@
 from os import getenv
 
 import connexion
-from api.routes.application.routes import ApplicationsView  # noqa
-from config import Config
 from connexion import FlaskApp
 from connexion.resolver import MethodResolver
-from db.exceptions.application import ApplicationError
 from flask import jsonify
 from fsd_utils import init_sentry
-from fsd_utils.healthchecks.checkers import DbChecker
-from fsd_utils.healthchecks.checkers import FlaskRunningChecker
+from fsd_utils.healthchecks.checkers import DbChecker, FlaskRunningChecker
 from fsd_utils.healthchecks.healthcheck import Healthcheck
 from fsd_utils.logging import logging
 from fsd_utils.services.aws_extended_client import SQSExtendedClient
+
+from api.routes.application.routes import ApplicationsView  # noqa
+from config import Config
+from db.exceptions.application import ApplicationError
 from openapi.utils import get_bundled_specs
 
 

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -1,12 +1,12 @@
 """Flask configuration."""
+
 import logging
 import os
+from distutils.util import strtobool
 from os import environ
 from pathlib import Path
 
-from distutils.util import strtobool
-from fsd_utils import CommonConfig
-from fsd_utils import configclass
+from fsd_utils import CommonConfig, configclass
 
 
 @configclass

--- a/config/envs/dev.py
+++ b/config/envs/dev.py
@@ -1,9 +1,11 @@
 """Flask configuration."""
+
 import logging
 from os import environ
 
-from config.envs.default import DefaultConfig
 from fsd_utils import configclass
+
+from config.envs.default import DefaultConfig
 
 
 @configclass

--- a/config/envs/development.py
+++ b/config/envs/development.py
@@ -1,8 +1,10 @@
 """Flask configuration."""
+
 import logging
 
-from config.envs.default import DefaultConfig
 from fsd_utils import configclass
+
+from config.envs.default import DefaultConfig
 
 
 @configclass

--- a/config/envs/production.py
+++ b/config/envs/production.py
@@ -1,8 +1,10 @@
 """Flask configuration."""
+
 from os import environ
 
-from config.envs.default import DefaultConfig
 from fsd_utils import configclass
+
+from config.envs.default import DefaultConfig
 
 
 @configclass

--- a/config/envs/test.py
+++ b/config/envs/test.py
@@ -1,8 +1,10 @@
 """Flask configuration."""
+
 from os import environ
 
-from config.envs.default import DefaultConfig
 from fsd_utils import configclass
+
+from config.envs.default import DefaultConfig
 
 
 @configclass

--- a/config/envs/unit_testing.py
+++ b/config/envs/unit_testing.py
@@ -1,5 +1,6 @@
 # flake8 : noqa
 """Flask Unit Testing Environment Configuration."""
+
 from os import environ
 
 from config.envs.default import DefaultConfig

--- a/config/key_report_mappings/cof25_eoi_key_report_mapping.py
+++ b/config/key_report_mappings/cof25_eoi_key_report_mapping.py
@@ -1,6 +1,4 @@
-from config.key_report_mappings.model import extract_postcode
-from config.key_report_mappings.model import FormMappingItem
-from config.key_report_mappings.model import KeyReportMapping
+from config.key_report_mappings.model import FormMappingItem, KeyReportMapping, extract_postcode
 
 COF25_EOI_KEY_REPORT_MAPPING = KeyReportMapping(
     round_id="9104d809-0fb0-4144-b514-55e81cc2b6fa",

--- a/config/key_report_mappings/cof_eoi_key_report_mapping.py
+++ b/config/key_report_mappings/cof_eoi_key_report_mapping.py
@@ -1,6 +1,4 @@
-from config.key_report_mappings.model import extract_postcode
-from config.key_report_mappings.model import FormMappingItem
-from config.key_report_mappings.model import KeyReportMapping
+from config.key_report_mappings.model import FormMappingItem, KeyReportMapping, extract_postcode
 
 COF_EOI_KEY_REPORT_MAPPING = KeyReportMapping(
     round_id="6a47c649-7bac-4583-baed-9c4e7a35c8b3",

--- a/config/key_report_mappings/cof_key_report_mapping.py
+++ b/config/key_report_mappings/cof_key_report_mapping.py
@@ -1,7 +1,9 @@
-from config.key_report_mappings.model import ApplicationColumnMappingItem
-from config.key_report_mappings.model import extract_postcode
-from config.key_report_mappings.model import FormMappingItem
-from config.key_report_mappings.model import KeyReportMapping
+from config.key_report_mappings.model import (
+    ApplicationColumnMappingItem,
+    FormMappingItem,
+    KeyReportMapping,
+    extract_postcode,
+)
 
 COF_KEY_REPORT_MAPPING = KeyReportMapping(
     round_id=["4efc3263-aefe-4071-b5f4-0910abec12d2", "33726b63-efce-4749-b149-20351346c76e"],

--- a/config/key_report_mappings/cof_r2_key_report_mapping.py
+++ b/config/key_report_mappings/cof_r2_key_report_mapping.py
@@ -1,6 +1,4 @@
-from config.key_report_mappings.model import extract_postcode
-from config.key_report_mappings.model import FormMappingItem
-from config.key_report_mappings.model import KeyReportMapping
+from config.key_report_mappings.model import FormMappingItem, KeyReportMapping, extract_postcode
 
 COF_R2_KEY_REPORT_MAPPING = KeyReportMapping(
     round_id="c603d114-5364-4474-a0c4-c41cbf4d3bbd",

--- a/config/key_report_mappings/cof_r3w2_key_report_mapping.py
+++ b/config/key_report_mappings/cof_r3w2_key_report_mapping.py
@@ -1,7 +1,9 @@
-from config.key_report_mappings.model import ApplicationColumnMappingItem
-from config.key_report_mappings.model import extract_postcode
-from config.key_report_mappings.model import FormMappingItem
-from config.key_report_mappings.model import KeyReportMapping
+from config.key_report_mappings.model import (
+    ApplicationColumnMappingItem,
+    FormMappingItem,
+    KeyReportMapping,
+    extract_postcode,
+)
 
 COF_R3W2_KEY_REPORT_MAPPING = KeyReportMapping(
     round_id="6af19a5e-9cae-4f00-9194-cf10d2d7c8a7",

--- a/config/key_report_mappings/cyp_r1_key_report_mapping.py
+++ b/config/key_report_mappings/cyp_r1_key_report_mapping.py
@@ -1,5 +1,4 @@
-from config.key_report_mappings.model import FormMappingItem
-from config.key_report_mappings.model import KeyReportMapping
+from config.key_report_mappings.model import FormMappingItem, KeyReportMapping
 
 CYP_R1_KEY_REPORT_MAPPING = KeyReportMapping(
     round_id="888aae3d-7e2c-4523-b9c1-95952b3d1644",

--- a/config/key_report_mappings/dpif_r2_key_report_mapping.py
+++ b/config/key_report_mappings/dpif_r2_key_report_mapping.py
@@ -1,5 +1,4 @@
-from config.key_report_mappings.model import FormMappingItem
-from config.key_report_mappings.model import KeyReportMapping
+from config.key_report_mappings.model import FormMappingItem, KeyReportMapping
 
 DPIF_R2_KEY_REPORT_MAPPING = KeyReportMapping(
     round_id="0059aad4-5eb5-11ee-8c99-0242ac120002",

--- a/config/key_report_mappings/mappings.py
+++ b/config/key_report_mappings/mappings.py
@@ -22,7 +22,6 @@ from config.key_report_mappings.dpif_r2_key_report_mapping import (
     DPIF_R2_KEY_REPORT_MAPPING,
 )
 
-
 ROUND_ID_TO_KEY_REPORT_MAPPING = defaultdict(
     lambda: COF_R2_KEY_REPORT_MAPPING.mapping,
     {

--- a/config/key_report_mappings/model.py
+++ b/config/key_report_mappings/model.py
@@ -1,7 +1,6 @@
 import re
 from dataclasses import dataclass
-from typing import Any
-from typing import Callable
+from typing import Any, Callable
 
 
 @dataclass

--- a/db/migrations/versions/5bf853808dfb_.py
+++ b/db/migrations/versions/5bf853808dfb_.py
@@ -5,6 +5,7 @@ Revises:
 Create Date: 2022-09-27 12:34:43.514139
 
 """
+
 import sqlalchemy as sa
 import sqlalchemy_utils
 from alembic import op

--- a/db/migrations/versions/d37dca03b539_.py
+++ b/db/migrations/versions/d37dca03b539_.py
@@ -5,9 +5,9 @@ Revises: f524201314e9
 Create Date: 2024-01-29 10:28:40.018763
 
 """
+
 import sqlalchemy as sa
 from alembic import op
-
 
 # revision identifiers, used by Alembic.
 revision = "d37dca03b539"

--- a/db/migrations/versions/e86cbf275e45_.py
+++ b/db/migrations/versions/e86cbf275e45_.py
@@ -5,6 +5,7 @@ Revises: f3332786bb2e
 Create Date: 2023-08-18 12:47:57.470108
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/db/migrations/versions/eb61bc354c57_.py
+++ b/db/migrations/versions/eb61bc354c57_.py
@@ -5,9 +5,9 @@ Revises: d37dca03b539
 Create Date: 2024-05-30 14:49:25.748523
 
 """
+
 import sqlalchemy as sa
 from alembic import op
-
 
 # revision identifiers, used by Alembic.
 revision = "eb61bc354c57"

--- a/db/migrations/versions/f3332786bb2e_.py
+++ b/db/migrations/versions/f3332786bb2e_.py
@@ -5,6 +5,7 @@ Revises: 5bf853808dfb
 Create Date: 2022-11-10 11:47:03.141413
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/db/migrations/versions/f524201314e9_.py
+++ b/db/migrations/versions/f524201314e9_.py
@@ -5,6 +5,7 @@ Revises: e86cbf275e45
 Create Date: 2023-08-25 20:25:36.554088
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/db/models/__init__.py
+++ b/db/models/__init__.py
@@ -1,7 +1,6 @@
 from .application import Applications
 from .eligibility import Eligibility
-from .feedback import EndOfApplicationSurveyFeedback
-from .feedback import Feedback
+from .feedback import EndOfApplicationSurveyFeedback, Feedback
 from .forms import Forms
 from .research import ResearchSurvey
 

--- a/db/models/application/applications.py
+++ b/db/models/application/applications.py
@@ -1,16 +1,13 @@
 import uuid
 
-from db import db
-from db.models.application.enums import Language
-from db.models.application.enums import Status
 from flask_sqlalchemy.model import DefaultMeta
-from sqlalchemy import Column
-from sqlalchemy import DateTime
-from sqlalchemy.dialects.postgresql import ENUM
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy import Column, DateTime
+from sqlalchemy.dialects.postgresql import ENUM, UUID
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 
+from db import db
+from db.models.application.enums import Language, Status
 
 BaseModel: DefaultMeta = db.Model
 

--- a/db/models/eligibility/eligibility.py
+++ b/db/models/eligibility/eligibility.py
@@ -1,13 +1,12 @@
 import uuid
 
-from db import db
-from db.models.application.applications import Applications
 from flask_sqlalchemy.model import DefaultMeta
-from sqlalchemy import Column
-from sqlalchemy import DateTime
+from sqlalchemy import Column, DateTime
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy_json import NestedMutableJson
 
+from db import db
+from db.models.application.applications import Applications
 
 BaseModel: DefaultMeta = db.Model
 

--- a/db/models/eligibility/eligibility_trail.py
+++ b/db/models/eligibility/eligibility_trail.py
@@ -1,11 +1,11 @@
 from uuid import uuid4
 
-from db import db
 from flask_sqlalchemy.model import DefaultMeta
 from sqlalchemy import Column
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.sql import func
 
+from db import db
 
 BaseModel: DefaultMeta = db.Model
 

--- a/db/models/feedback/end_of_application_survey.py
+++ b/db/models/feedback/end_of_application_survey.py
@@ -1,9 +1,9 @@
-from db import db
 from flask_sqlalchemy.model import DefaultMeta
 from sqlalchemy import DateTime
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.sql import func
 
+from db import db
 
 BaseModel: DefaultMeta = db.Model
 

--- a/db/models/feedback/feedback.py
+++ b/db/models/feedback/feedback.py
@@ -1,13 +1,14 @@
 import uuid
 
-from db import db
-from db.models.application.applications import Applications
-from db.models.application.enums import Status
 from flask_sqlalchemy.model import DefaultMeta
 from sqlalchemy import DateTime
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.sql import func
 from sqlalchemy_json import NestedMutableJson
+
+from db import db
+from db.models.application.applications import Applications
+from db.models.application.enums import Status
 
 BaseModel: DefaultMeta = db.Model
 

--- a/db/models/forms/forms.py
+++ b/db/models/forms/forms.py
@@ -1,10 +1,11 @@
 import uuid
 
-from db import db
-from db.models.application.applications import Applications
 from flask_sqlalchemy.model import DefaultMeta
 from sqlalchemy_json import NestedMutableJson
 from sqlalchemy_utils.types import UUIDType
+
+from db import db
+from db.models.application.applications import Applications
 
 from .enums import Status
 

--- a/db/models/research/research.py
+++ b/db/models/research/research.py
@@ -1,9 +1,9 @@
-from db import db
 from flask_sqlalchemy.model import DefaultMeta
 from sqlalchemy import DateTime
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.sql import func
 
+from db import db
 
 BaseModel: DefaultMeta = db.Model
 

--- a/db/queries/__init__.py
+++ b/db/queries/__init__.py
@@ -1,22 +1,22 @@
-from .application import create_application
-from .application import get_application
-from .application import get_applications
-from .application import get_count_by_status
-from .application import get_fund_id
-from .application import search_applications
-from .application import submit_application
-from .feedback import get_feedback
-from .feedback import upsert_feedback
-from .form import add_new_forms
-from .form import get_form
-from .form import get_forms_by_app_id
-from .reporting import export_json_to_csv
-from .reporting import export_json_to_excel
-from .reporting import get_general_status_applications_report
-from .reporting import get_key_report_field_headers
-from .reporting import get_report_for_applications
-from .updating import update_application_and_related_form
-from .updating import update_form
+from .application import (
+    create_application,
+    get_application,
+    get_applications,
+    get_count_by_status,
+    get_fund_id,
+    search_applications,
+    submit_application,
+)
+from .feedback import get_feedback, upsert_feedback
+from .form import add_new_forms, get_form, get_forms_by_app_id
+from .reporting import (
+    export_json_to_csv,
+    export_json_to_excel,
+    get_general_status_applications_report,
+    get_key_report_field_headers,
+    get_report_for_applications,
+)
+from .updating import update_application_and_related_form, update_form
 
 __all__ = [
     create_application,

--- a/db/queries/feedback/queries.py
+++ b/db/queries/feedback/queries.py
@@ -1,16 +1,16 @@
 from datetime import datetime
 
+from flask import current_app
+
 from config.key_report_mappings.mappings import get_report_mapping_for_round
 from db import db
-from db.models import Applications
-from db.models import Feedback
+from db.models import Applications, Feedback
 from db.models.feedback import EndOfApplicationSurveyFeedback
 from db.queries.application.queries import get_applications
 from db.queries.reporting.queries import map_application_key_fields
 from db.schemas.application import ApplicationSchema
 from db.schemas.end_of_application_survey import EndOfApplicationSurveyFeedbackSchema
 from external_services.data import get_application_sections
-from flask import current_app
 
 
 def upsert_feedback(application_id, fund_id, round_id, section_id, feedback_json, status):
@@ -125,7 +125,10 @@ def retrieve_all_feedbacks_and_surveys(fund_id, round_id, status):
             applicant_email = result["applicant_email"]
             applicant_organisation = result["organisation_name"]
         except Exception as e:
-            current_app.logger.error(f"Coudn't extract applicant email & organisation.  Exception :{e}")
+            current_app.logger.error(
+                "Coudn't extract applicant email & organisation.  Exception :{error}",
+                extra=dict(error=e),
+            )
             applicant_email = ""
             applicant_organisation = ""
 

--- a/db/queries/reporting/queries.py
+++ b/db/queries/reporting/queries.py
@@ -1,13 +1,11 @@
 import csv
 import io
-from typing import Any
-from typing import Optional
+from typing import Any, Optional
 
 import pandas as pd
+
 from config.key_report_mappings.mappings import ROUND_ID_TO_KEY_REPORT_MAPPING
-from config.key_report_mappings.model import ApplicationColumnMappingItem
-from config.key_report_mappings.model import FormMappingItem
-from config.key_report_mappings.model import MappingItem
+from config.key_report_mappings.model import ApplicationColumnMappingItem, FormMappingItem, MappingItem
 from db.models import Applications
 from db.queries import get_applications
 from db.queries.application import get_count_by_status

--- a/db/schemas/application.py
+++ b/db/schemas/application.py
@@ -1,14 +1,11 @@
-from db.models import Applications
-from db.models.application.enums import Language
-from db.models.application.enums import Status
-from external_services import get_round_name
 from marshmallow import post_dump
-from marshmallow.fields import DateTime
-from marshmallow.fields import Enum
-from marshmallow.fields import Method
-from marshmallow_sqlalchemy import auto_field
-from marshmallow_sqlalchemy import SQLAlchemyAutoSchema
+from marshmallow.fields import DateTime, Enum, Method
+from marshmallow_sqlalchemy import SQLAlchemyAutoSchema, auto_field
 from marshmallow_sqlalchemy.fields import Nested
+
+from db.models import Applications
+from db.models.application.enums import Language, Status
+from external_services import get_round_name
 
 from .form import FormsRunnerSchema
 

--- a/db/schemas/eligibility.py
+++ b/db/schemas/eligibility.py
@@ -1,7 +1,8 @@
-from db.models import Eligibility
-from db.models.eligibility.eligibility_trail import EligibilityUpdate
 from marshmallow import post_dump
 from marshmallow_sqlalchemy import SQLAlchemyAutoSchema
+
+from db.models import Eligibility
+from db.models.eligibility.eligibility_trail import EligibilityUpdate
 
 
 class EligibilitySchema(SQLAlchemyAutoSchema):

--- a/db/schemas/end_of_application_survey.py
+++ b/db/schemas/end_of_application_survey.py
@@ -1,6 +1,6 @@
+from marshmallow_sqlalchemy import SQLAlchemySchema, auto_field
+
 from db.models import EndOfApplicationSurveyFeedback
-from marshmallow_sqlalchemy import auto_field
-from marshmallow_sqlalchemy import SQLAlchemySchema
 
 
 class EndOfApplicationSurveyFeedbackSchema(SQLAlchemySchema):

--- a/db/schemas/feedback.py
+++ b/db/schemas/feedback.py
@@ -1,9 +1,8 @@
+from marshmallow.fields import DateTime, Enum
+from marshmallow_sqlalchemy import SQLAlchemySchema, auto_field
+
 from db.models import Feedback
 from db.models.feedback.enums import Status
-from marshmallow.fields import DateTime
-from marshmallow.fields import Enum
-from marshmallow_sqlalchemy import auto_field
-from marshmallow_sqlalchemy import SQLAlchemySchema
 
 
 class FeedbackSchema(SQLAlchemySchema):

--- a/db/schemas/form.py
+++ b/db/schemas/form.py
@@ -1,8 +1,8 @@
+from marshmallow.fields import Enum
+from marshmallow_sqlalchemy import SQLAlchemySchema, auto_field
+
 from db.models import Forms
 from db.models.forms.enums import Status
-from marshmallow.fields import Enum
-from marshmallow_sqlalchemy import auto_field
-from marshmallow_sqlalchemy import SQLAlchemySchema
 
 
 class FormsRunnerSchema(SQLAlchemySchema):

--- a/external_services/aws.py
+++ b/external_services/aws.py
@@ -2,6 +2,7 @@ from collections import namedtuple
 from os import getenv
 
 import boto3
+
 from config import Config
 
 _KEY_PARTS = ("application_id", "form", "path", "component_id", "filename")

--- a/external_services/data.py
+++ b/external_services/data.py
@@ -5,9 +5,9 @@ from typing import Optional
 from urllib.parse import urlencode
 
 import requests
+from flask import abort, current_app
+
 from config import Config
-from flask import abort
-from flask import current_app
 
 from .models.account import Account
 from .models.fund import Fund
@@ -27,13 +27,22 @@ def get_data(endpoint: str, params: Optional[dict] = None):
     """
 
     if Config.USE_LOCAL_DATA:
-        current_app.logger.info(f"Fetching local data from '{endpoint}'" + f" with params {params}.")
+        current_app.logger.info(
+            "Fetching local data from '{endpoint}' with params {params}.",
+            extra=dict(endpoint=endpoint, params=params),
+        )
         data = get_local_data(endpoint, params)
     else:
-        current_app.logger.info(f"Fetching data from '{endpoint}'" + f" with params {params}.")
+        current_app.logger.info(
+            "Fetching data from '{endpoint}' with params {params}.",
+            extra=dict(endpoint=endpoint, params=params),
+        )
         data = get_remote_data(endpoint, params)
     if data is None:
-        current_app.logger.error(f"Data request failed, unable to recover: {endpoint}")
+        current_app.logger.error(
+            "Data request failed, unable to recover: {endpoint}",
+            extra=dict(endpoint=endpoint),
+        )
         return abort(500)
     return data
 
@@ -51,7 +60,10 @@ def get_remote_data(endpoint, params: Optional[dict] = None):
         data = response.json()
         return data
     else:
-        current_app.logger.warn(f"GET remote data call was unsuccessful with status code: {response.status_code}.")
+        current_app.logger.warning(
+            "GET remote data call was unsuccessful with status code: {status_code}.",
+            extra=dict(status_code=response.status_code),
+        )
         return None
 
 
@@ -93,7 +105,7 @@ def get_funds() -> list[Fund] | None:
 
 def get_fund(fund_id: str) -> Fund | None:
     endpoint = Config.FUND_STORE_API_HOST + Config.FUND_ENDPOINT.format(fund_id=fund_id)
-    current_app.logger.info(f"Request made to {endpoint}")
+    current_app.logger.info("Request made to {endpoint}", extra=dict(endpoint=endpoint))
     response = get_data(endpoint)
     if response is None:
         current_app.logger.info("Request to fund store returned None")

--- a/external_services/http_methods.py
+++ b/external_services/http_methods.py
@@ -3,24 +3,31 @@ import os
 from typing import Optional
 
 import requests
+from flask import current_app
+
 from config import Config
 from external_services.exceptions import NotificationError
-from flask import current_app
 
 
 def post_data(endpoint: str, json_payload: Optional[dict] = None) -> dict:
     if Config.USE_LOCAL_DATA:
-        current_app.logger.info(f"Posting to local dummy endpoint: {endpoint}")
+        current_app.logger.info("Posting to local dummy endpoint: {endpoint}", extra=dict(endpoint=endpoint))
         response = post_local_data(endpoint)
 
     else:
         if json_payload:
             json_payload = {k: v for k, v in json_payload.items() if v is not None}
-        current_app.logger.info(f"Attempting POST to the following endpoint: '{endpoint}'.")
+        current_app.logger.info(
+            "Attempting POST to the following endpoint: '{endpoint}'.",
+            extra=dict(endpoint=endpoint),
+        )
         response = requests.post(endpoint, json=json_payload)
 
     if response.status_code in [200, 201]:
-        current_app.logger.info(f"Post successfully sent to {endpoint} with response code: '{response.status_code}'.")
+        current_app.logger.info(
+            "Post successfully sent to {endpoint} with response code: '{status_code}'.",
+            extra=dict(endpoint=endpoint, status_code=response.status_code),
+        )
 
         return response.json()
 

--- a/external_services/models/fund.py
+++ b/external_services/models/fund.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
 from typing import Optional
 
-from external_services.models.round import Round
 from flask import current_app
+
+from external_services.models.round import Round
 
 
 @dataclass

--- a/openapi/utils.py
+++ b/openapi/utils.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 import prance
+
 from config import Config
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,12 +34,25 @@ dependencies = [
     "uvicorn==0.30.3",
 ]
 
-[tool.black]
-line-length = 120
 
-[tool.flake8]
-max-line-length = 120
-count = true
+[tool.ruff.lint]
+select = [
+    "E",  # pycodestyle
+    "W",  # pycodestyle
+    "F",  # pyflakes
+    "I",  # isort
+    "B",  # flake8-bugbear
+    "C90",  # mccabe cyclomatic complexity
+    "G",  # flake8-logging-format
+]
+ignore = []
+exclude = [
+    "db/migrations/versions/",
+    "venv*",
+    ".venv*",
+    "__pycache__",
+]
+mccabe.max-complexity = 12
 
 [tool.uv]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,8 @@ dependencies = [
     "uvicorn==0.30.3",
 ]
 
+[tool.ruff]
+line-length = 120
 
 [tool.ruff.lint]
 select = [

--- a/scripts/seed_db_test_data.py
+++ b/scripts/seed_db_test_data.py
@@ -4,16 +4,16 @@ import click
 
 sys.path.insert(1, ".")
 
+from fsd_test_utils.test_config.useful_config import UsefulConfig  # noqa: E402
+
 from app import app  # noqa: E402
 from db.models.application.applications import Status  # noqa: E402
-from fsd_test_utils.test_config.useful_config import UsefulConfig  # noqa: E402
-from tests.seed_data.seed_db import seed_in_progress_application  # noqa: E402
 from tests.seed_data.seed_db import (  # noqa: E402
-    seed_not_started_application,
     seed_completed_application,
+    seed_in_progress_application,  # noqa: E402
+    seed_not_started_application,
     seed_submitted_application,
 )  # noqa: E402
-
 
 FUND_CONFIG = {
     "COF": {
@@ -93,7 +93,7 @@ def seed_applications(fund_short_code, round_short_code, account_id, status, cou
     round_config = fund_config["rounds"][round_short_code]
     match status:
         case Status.NOT_STARTED.name:
-            for i in range(count):
+            for _i in range(count):
                 app = seed_not_started_application(
                     fund_config=fund_config,
                     round_config=round_config,
@@ -102,7 +102,7 @@ def seed_applications(fund_short_code, round_short_code, account_id, status, cou
                 )
                 print(f"{app.id} - {app.reference} - {app.status.name}")
         case Status.IN_PROGRESS.name:
-            for i in range(count):
+            for _i in range(count):
                 app = seed_in_progress_application(
                     fund_config=fund_config,
                     round_config=round_config,
@@ -111,7 +111,7 @@ def seed_applications(fund_short_code, round_short_code, account_id, status, cou
                 )
                 print(f"{app.id} - {app.reference} - {app.status.name}")
         case Status.COMPLETED.name:
-            for i in range(count):
+            for _i in range(count):
                 app = seed_completed_application(
                     fund_config=fund_config,
                     round_config=round_config,
@@ -120,7 +120,7 @@ def seed_applications(fund_short_code, round_short_code, account_id, status, cou
                 )
                 print(f"{app.id} - {app.reference} - {app.status.name}")
         case Status.SUBMITTED.name:
-            for i in range(count):
+            for _i in range(count):
                 app = seed_submitted_application(
                     fund_config=fund_config,
                     round_config=round_config,

--- a/tasks.py
+++ b/tasks.py
@@ -2,11 +2,8 @@ import os
 import venv
 from pathlib import Path
 
-from colored import attr
-from colored import fg
-from colored import stylize
+from colored import attr, fg, stylize
 from invoke import task
-
 
 ECHO_STYLE = fg("light_gray") + attr("bold")
 

--- a/testing.py
+++ b/testing.py
@@ -12,7 +12,7 @@ def print_data():
 
 
 executor = ThreadPoolExecutor(max_workers=5, thread_name_prefix="TestingExecutor")
-for x in range(4):
+for _x in range(4):
     executor.submit(print_data)
 
 print_data()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,20 +1,21 @@
-from datetime import datetime
-from datetime import timedelta
+from datetime import datetime, timedelta
 from uuid import uuid4
 
 import pytest
+from flask import Response
+
 from app import create_app
 from db.models.application.applications import Applications
 from db.queries.application import create_application
 from db.queries.form import add_new_forms
-from external_services.models.fund import Fund
-from external_services.models.fund import Round
-from flask import Response
-from tests.helpers import APPLICATION_DISPLAY_CONFIG
-from tests.helpers import local_api_call
-from tests.helpers import test_application_data
-from tests.helpers import test_question_data
-from tests.helpers import test_question_data_cy
+from external_services.models.fund import Fund, Round
+from tests.helpers import (
+    APPLICATION_DISPLAY_CONFIG,
+    local_api_call,
+    test_application_data,
+    test_question_data,
+    test_question_data_cy,
+)
 
 # Make the utils fixtures available, used in seed_application_records
 pytest_plugins = ["fsd_test_utils.fixtures.db_fixtures"]

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -4,9 +4,10 @@ import re
 import urllib
 from datetime import datetime
 
+from deepdiff import DeepDiff
+
 from config import Config
 from db.models.application.enums import Language
-from deepdiff import DeepDiff
 
 
 def get_row_by_pk(table, primary_key):
@@ -317,14 +318,14 @@ def post_test_applications(client):
 
 
 def key_list_to_regex(
-    exclude_keys: list[str] = [
+    exclude_keys: list[str] = (
         "id",
         "reference",
         "started_at",
         "project_name",
         "last_edited",
         "date_submitted",
-    ]
+    ),
 ):
     exclude_regex_path_strings = [rf"root\[\d+\]\['{key}'\]" for key in exclude_keys]
 

--- a/tests/seed_data/seed_db.py
+++ b/tests/seed_data/seed_db.py
@@ -3,8 +3,7 @@ import json
 from _helpers import get_blank_forms
 from db.models.application import Applications
 from db.queries import add_new_forms
-from db.queries.application import create_application
-from db.queries.application import submit_application
+from db.queries.application import create_application, submit_application
 from db.queries.updating.queries import update_form
 
 

--- a/tests/test_all_feedbacks.py
+++ b/tests/test_all_feedbacks.py
@@ -1,11 +1,9 @@
 import pytest
+
 from config.key_report_mappings.cof_r3w2_key_report_mapping import (
     COF_R3W2_KEY_REPORT_MAPPING,
 )
-from db.models import Applications
-from db.models import EndOfApplicationSurveyFeedback
-from db.models import Feedback
-from db.models import Forms
+from db.models import Applications, EndOfApplicationSurveyFeedback, Feedback, Forms
 from db.queries.feedback import retrieve_all_feedbacks_and_surveys
 
 app_sections = [

--- a/tests/test_application_status.py
+++ b/tests/test_application_status.py
@@ -1,14 +1,17 @@
 from unittest.mock import MagicMock
 
 import pytest
-from db.queries.statuses.queries import _determine_question_page_status_from_answers
-from db.queries.statuses.queries import _is_all_sections_feedback_complete
-from db.queries.statuses.queries import _is_feedback_survey_complete
-from db.queries.statuses.queries import _is_field_answered
-from db.queries.statuses.queries import _is_research_survey_complete
-from db.queries.statuses.queries import update_application_status
-from db.queries.statuses.queries import update_form_status
-from db.queries.statuses.queries import update_question_page_statuses
+
+from db.queries.statuses.queries import (
+    _determine_question_page_status_from_answers,
+    _is_all_sections_feedback_complete,
+    _is_feedback_survey_complete,
+    _is_field_answered,
+    _is_research_survey_complete,
+    update_application_status,
+    update_form_status,
+    update_question_page_statuses,
+)
 from external_services.models.round import FeedbackSurveyConfig
 
 
@@ -57,8 +60,8 @@ def test_update_question_statuses_with_mocks(mocker):
 
     assert test_json[0]["status"] == "NOT_STARTED"
     assert test_json[1]["status"] == "NOT_STARTED"
-    mock_question_status.call_count == 2
-    mock_answer_status.call_count == 2
+    assert mock_question_status.call_count == 2
+    assert mock_answer_status.call_count == 2
 
 
 @pytest.mark.parametrize(

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -1,4 +1,5 @@
 import pytest
+
 from external_services.aws import list_files_by_prefix
 
 

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,6 +1,5 @@
 from _helpers.form import get_forms_from_sections
 
-
 section_config = [
     {
         "form_name": None,

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -4,12 +4,13 @@ from unittest.mock import MagicMock
 
 import boto3
 import pytest
-from config import Config
-from external_services.exceptions import NotificationError
-from external_services.models.notification import Notification
 from fsd_utils import NotifyConstants
 from fsd_utils.services.aws_extended_client import SQSExtendedClient
 from moto import mock_aws
+
+from config import Config
+from external_services.exceptions import NotificationError
+from external_services.models.notification import Notification
 
 
 class NotificationTest(unittest.TestCase):

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -3,6 +3,7 @@ from unittest.mock import ANY
 from uuid import uuid4
 
 import pytest
+
 from config.key_report_mappings.cof_eoi_key_report_mapping import COF_EOI_KEY_REPORT_MAPPING
 from config.key_report_mappings.cof_key_report_mapping import COF_KEY_REPORT_MAPPING
 from config.key_report_mappings.cof_r2_key_report_mapping import (
@@ -12,15 +13,10 @@ from config.key_report_mappings.cof_r3w2_key_report_mapping import (
     COF_R3W2_KEY_REPORT_MAPPING,
 )
 from config.key_report_mappings.mappings import ROUND_ID_TO_KEY_REPORT_MAPPING
-from config.key_report_mappings.model import extract_postcode
-from config.key_report_mappings.model import KeyReportMapping
-from db.models import Applications
-from db.models import Forms
-from db.queries.application import create_application
-from db.queries.application import create_qa_base64file
-from db.queries.application import process_files
-from db.queries.reporting.queries import export_application_statuses_to_csv
-from db.queries.reporting.queries import map_application_key_fields
+from config.key_report_mappings.model import KeyReportMapping, extract_postcode
+from db.models import Applications, Forms
+from db.queries.application import create_application, create_qa_base64file, process_files
+from db.queries.reporting.queries import export_application_statuses_to_csv, map_application_key_fields
 from external_services.aws import FileData
 from external_services.models.fund import Fund
 from tests.seed_data.application_data import expected_application_json
@@ -196,7 +192,7 @@ def test_process_files(application, all_application_files, expected):
     THEN the application object is expected to be updated with the relevant file information
     """
     result = process_files(application, all_application_files)
-    for form, expected_form in zip(result.forms, expected.forms):
+    for form, expected_form in zip(result.forms, expected.forms, strict=False):
         assert form.json == pytest.approx(expected_form.json)
 
 

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,8 +1,8 @@
 import pytest
+
 from db.models import Applications
 from db.models.application.enums import Status
-from tests.helpers import get_row_by_pk
-from tests.helpers import test_application_data
+from tests.helpers import get_row_by_pk, test_application_data
 
 
 @pytest.mark.apps_to_insert(test_application_data)
@@ -244,8 +244,7 @@ def test_get_applications_report_query_param(flask_test_client, seed_data_multip
 
     lines = [line.decode("utf-8") for line in response.content.splitlines()]
     assert (
-        lines[0]
-        == "eoi_reference,organisation_name,organisation_type,asset_type,"
+        lines[0] == "eoi_reference,organisation_name,organisation_type,asset_type,"
         "geography,capital,revenue,organisation_name_nstf"
     )
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,31 +1,31 @@
 import json
-from datetime import datetime
-from datetime import timedelta
+from datetime import datetime, timedelta
 from unittest import mock
-from unittest.mock import ANY
-from unittest.mock import MagicMock
+from unittest.mock import ANY, MagicMock
 from uuid import uuid4
 
 import boto3
 import pytest
+from fsd_utils.services.aws_extended_client import SQSExtendedClient
+from moto import mock_aws
+
 from config import Config
 from db import db
-from db.models import Applications
-from db.models import ResearchSurvey
+from db.models import Applications, ResearchSurvey
 from db.queries.application import get_all_applications
 from db.schemas import ApplicationSchema
 from external_services.models.fund import Fund
 from external_services.models.round import Round
-from fsd_utils.services.aws_extended_client import SQSExtendedClient
-from moto import mock_aws
-from tests.helpers import application_expected_data
-from tests.helpers import count_fund_applications
-from tests.helpers import expected_data_within_response
-from tests.helpers import get_row_by_pk
-from tests.helpers import key_list_to_regex
-from tests.helpers import post_data
-from tests.helpers import test_application_data
-from tests.helpers import test_question_data
+from tests.helpers import (
+    application_expected_data,
+    count_fund_applications,
+    expected_data_within_response,
+    get_row_by_pk,
+    key_list_to_regex,
+    post_data,
+    test_application_data,
+    test_question_data,
+)
 
 
 @pytest.mark.unique_fund_round(True)

--- a/tests/test_seed_db.py
+++ b/tests/test_seed_db.py
@@ -3,16 +3,18 @@ from unittest.mock import MagicMock
 from uuid import uuid4
 
 import pytest
+
 from config import Config
 from db.models.application.applications import Status
 from db.queries.application import get_application_status
 from db.queries.form import get_forms_by_app_id
 from scripts.seed_db_test_data import FUND_CONFIG
-from tests.seed_data.seed_db import seed_completed_application
-from tests.seed_data.seed_db import seed_in_progress_application
-from tests.seed_data.seed_db import seed_not_started_application
-from tests.seed_data.seed_db import seed_submitted_application
-
+from tests.seed_data.seed_db import (
+    seed_completed_application,
+    seed_in_progress_application,
+    seed_not_started_application,
+    seed_submitted_application,
+)
 
 LANG_EN = "en"
 COF = FUND_CONFIG["COF"]

--- a/tests/test_send_app_on_closure.py
+++ b/tests/test_send_app_on_closure.py
@@ -1,5 +1,6 @@
 import pytest
 from pytest import raises
+
 from scripts.send_application_on_closure import (
     send_incomplete_applications_after_deadline,
 )


### PR DESCRIPTION
In pre-award-stores we are using ruff for formatting (replacing flake8 and black). As application store will shortly be moved into pre-award stores, this PR makes the formatting changes as a precursor to the merge. 

- Updated log messages to use the `extra` arg instead of `f-strings`
- Prefixing unused loop vars with `-`
- A couple of `noqa` markers added for things that need a bigger refactor to fix properly