### PR TITLE
Read fund-store host from parameter store

### DIFF
--- a/copilot/fsd-application-store/manifest.yml
+++ b/copilot/fsd-application-store/manifest.yml
@@ -57,11 +57,10 @@ variables:
     from_cfn: ${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}-NotificationQueueURL
   AWS_SQS_NOTIF_APP_SECONDARY_QUEUE_URL:
     from_cfn: ${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}-NotificationDeadLetterQueueURL
-
   ACCOUNT_STORE_API_HOST: http://fsd-account-store:8080
-  FUND_STORE_API_HOST: http://fsd-fund-store:8080
 
 secrets:
+  FUND_STORE_API_HOST: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/FUND_STORE_API_HOST
   SECRET_KEY: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/SECRET_KEY
 
 # You can override any of the values defined above by environment.


### PR DESCRIPTION
### Change description
This will help us migrate from the "microservice"-y fund-store to a more consolidated pre-award-stores service.

Ticket: https://mhclgdigital.atlassian.net/browse/FSPT-108